### PR TITLE
Game_Message#allText will throw error when Game_Message#_texts is empty array

### DIFF
--- a/src/rpg_objects/Game_Message.js
+++ b/src/rpg_objects/Game_Message.js
@@ -184,7 +184,5 @@ Game_Message.prototype.newPage = function() {
 };
 
 Game_Message.prototype.allText = function() {
-    return this._texts.reduce(function(previousValue, currentValue) {
-        return previousValue + '\n' + currentValue;
-    });
+    return this._texts.join('\n');
 };


### PR DESCRIPTION
### about

`Array.prototype.reduce` will throw TypeError when array is empty and no initial value.
To resolve this probrem, just use `Array.prototype.join`.

