### PR TITLE
Fix mirrored animation.

### DIFF
--- a/js/rpg_sprites/Sprite_Animation.js
+++ b/js/rpg_sprites/Sprite_Animation.js
@@ -49,6 +49,11 @@ Sprite_Animation.prototype.setup = function(target, animation, mirror, delay) {
         this.setupDuration();
         this.loadBitmaps();
         this.createSprites();
+        if (this._mirror) {
+            this.scale.x = -1;
+        } else {
+            this.scale.x = 1;
+        }
     }
 };
 
@@ -255,7 +260,7 @@ Sprite_Animation.prototype.updateCellSprite = function(sprite, cell) {
         }
         sprite.rotation = cell[4] * Math.PI / 180;
         sprite.scale.x = cell[3] / 100;
-        if ((cell[5] && !mirror) || (!cell[5] && mirror)) {
+        if (cell[5]) {
             sprite.scale.x *= -1;
         }
         sprite.scale.y = cell[3] / 100;


### PR DESCRIPTION
sample:https://ralph-vx.github.io/mvwebsample/www/index.html

The problem occurs when 'Sprite_Animation.setup' is called with parameter 'mirror' with 'true', and the animation contains any cell that is mirrored and has a rotation in it.

In the sample above, left event playing animation ordinary, while right one is calling 'Sprite_Character.startAnimation' with the same animation and set parameter 'mirror' as 'true'. The right one is in fact not mirrored but rotated 90 degrees.

This functionality is used when an actor attack while he is dual wielding, so I assume the animation with 'mirror' parameter set to 'true' should look exactly same as the original animation apart with being mirrored.

Change in the request only fix the problem in here, but the same issue maybe exists in other places, as this probably caused by the order of the transformation in render time (scaled then rotation, or rotated then scale), and maybe it is better to give some handle of this to the user? IDK really.

