### PR TITLE
fix can't change volume after it fadein

### DIFF
--- a/js/rpg_core/WebAudio.js
+++ b/js/rpg_core/WebAudio.js
@@ -112,7 +112,7 @@ WebAudio._createMasterGainNode = function() {
     var context = WebAudio._context;
     if (context) {
         this._masterGainNode = context.createGain();
-        this._masterGainNode.gain.value = 1;
+        this._masterGainNode.gain.setValueAtTime(1, context.currentTime);
         this._masterGainNode.connect(context.destination);
     }
 };
@@ -268,8 +268,7 @@ Object.defineProperty(WebAudio.prototype, 'volume', {
     set: function(value) {
         this._volume = value;
         if (this._gainNode) {
-            this._gainNode.gain.cancelScheduledValues(0);
-            this._gainNode.gain.value = this._volume;
+            this._gainNode.gain.setValueAtTime(this._volume, WebAudio._context.currentTime);
         }
     },
     configurable: true
@@ -530,9 +529,9 @@ WebAudio.prototype._createNodes = function() {
     this._sourceNode.buffer = this._buffer;
     this._sourceNode.loopStart = this._loopStart;
     this._sourceNode.loopEnd = this._loopStart + this._loopLength;
-    this._sourceNode.playbackRate.value = this._pitch;
+    this._sourceNode.playbackRate.setValueAtTime(this._pitch, context.currentTime);
     this._gainNode = context.createGain();
-    this._gainNode.gain.value = this._volume;
+    this._gainNode.gain.setValueAtTime(this._volume, context.currentTime);
     this._pannerNode = context.createPanner();
     this._pannerNode.panningModel = 'equalpower';
     this._updatePanner();

--- a/js/rpg_core/WebAudio.js
+++ b/js/rpg_core/WebAudio.js
@@ -268,6 +268,7 @@ Object.defineProperty(WebAudio.prototype, 'volume', {
     set: function(value) {
         this._volume = value;
         if (this._gainNode) {
+            this._gainNode.gain.cancelScheduledValues(0);
             this._gainNode.gain.value = this._volume;
         }
     },


### PR DESCRIPTION
RMMV's WebAudio contains several bugs.

- Can't change BGM volume after playing ME
- Can't change BGM volume after replaying BGM
- Can't change BGM and BGS volume after battle end

The cause of all these bugs is "Can't change volume after it fadein".

This is caused by the strange specification of WebAudio AudioParam. (For details, see https://github.com/WebAudio/web-audio-api/issues/128)
Changes to `value` are ignored after` setValueAtTime` or `linearRampToValueAtTime` is called.
Therefore, I decided to cancel these schedules when changing `value`.