### PR TITLE
fix lack of reserveFace

### DIFF
--- a/js/rpg_scenes/Scene_Menu.js
+++ b/js/rpg_scenes/Scene_Menu.js
@@ -48,6 +48,7 @@ Scene_Menu.prototype.createGoldWindow = function() {
 
 Scene_Menu.prototype.createStatusWindow = function() {
     this._statusWindow = new Window_MenuStatus(this._commandWindow.width, 0);
+    this._statusWindow.reserveFaceImages();
     this.addWindow(this._statusWindow);
 };
 

--- a/js/rpg_scenes/Scene_Skill.js
+++ b/js/rpg_scenes/Scene_Skill.js
@@ -21,12 +21,11 @@ Scene_Skill.prototype.create = function() {
     this.createStatusWindow();
     this.createItemWindow();
     this.createActorWindow();
-    this.refreshActor();
 };
 
 Scene_Skill.prototype.start = function() {
     Scene_ItemBase.prototype.start.call(this);
-    this._statusWindow.refresh();
+    this.refreshActor();
 };
 
 Scene_Skill.prototype.createSkillTypeWindow = function() {

--- a/js/rpg_scenes/Scene_Skill.js
+++ b/js/rpg_scenes/Scene_Skill.js
@@ -45,6 +45,7 @@ Scene_Skill.prototype.createStatusWindow = function() {
     var ww = Graphics.boxWidth - wx;
     var wh = this._skillTypeWindow.height;
     this._statusWindow = new Window_SkillStatus(wx, wy, ww, wh);
+    this._statusWindow.reserveFaceImages();
     this.addWindow(this._statusWindow);
 };
 

--- a/js/rpg_scenes/Scene_Skill.js
+++ b/js/rpg_scenes/Scene_Skill.js
@@ -24,6 +24,11 @@ Scene_Skill.prototype.create = function() {
     this.refreshActor();
 };
 
+Scene_Skill.prototype.start = function() {
+    Scene_ItemBase.prototype.start.call(this);
+    this._statusWindow.refresh();
+};
+
 Scene_Skill.prototype.createSkillTypeWindow = function() {
     var wy = this._helpWindow.height;
     this._skillTypeWindow = new Window_SkillType(0, wy);

--- a/js/rpg_scenes/Scene_Status.js
+++ b/js/rpg_scenes/Scene_Status.js
@@ -20,6 +20,7 @@ Scene_Status.prototype.create = function() {
     this._statusWindow.setHandler('cancel',   this.popScene.bind(this));
     this._statusWindow.setHandler('pagedown', this.nextActor.bind(this));
     this._statusWindow.setHandler('pageup',   this.previousActor.bind(this));
+    this._statusWindow.reserveFaceImages();
     this.addWindow(this._statusWindow);
 };
 

--- a/js/rpg_scenes/Scene_Status.js
+++ b/js/rpg_scenes/Scene_Status.js
@@ -21,12 +21,11 @@ Scene_Status.prototype.create = function() {
     this._statusWindow.setHandler('pagedown', this.nextActor.bind(this));
     this._statusWindow.setHandler('pageup',   this.previousActor.bind(this));
     this.addWindow(this._statusWindow);
-    this.refreshActor();
 };
 
 Scene_Status.prototype.start = function() {
     Scene_MenuBase.prototype.start.call(this);
-    this._statusWindow.refresh();
+    this.refreshActor();
 };
 
 Scene_Status.prototype.refreshActor = function() {

--- a/js/rpg_scenes/Scene_Status.js
+++ b/js/rpg_scenes/Scene_Status.js
@@ -24,6 +24,11 @@ Scene_Status.prototype.create = function() {
     this.refreshActor();
 };
 
+Scene_Status.prototype.start = function() {
+    Scene_MenuBase.prototype.start.call(this);
+    this._statusWindow.refresh();
+};
+
 Scene_Status.prototype.refreshActor = function() {
     var actor = this.actor();
     this._statusWindow.setActor(actor);

--- a/js/rpg_windows/Window_Base.js
+++ b/js/rpg_windows/Window_Base.js
@@ -697,3 +697,9 @@ Window_Base.prototype.canvasToLocalY = function(y) {
     }
     return y;
 };
+
+Window_Base.prototype.reserveFaceImages = function() {
+    $gameParty.members().forEach(function(actor) {
+        ImageManager.reserveFace(actor.faceName());
+    }, this);
+};

--- a/js/rpg_windows/Window_MenuStatus.js
+++ b/js/rpg_windows/Window_MenuStatus.js
@@ -16,7 +16,6 @@ Window_MenuStatus.prototype.initialize = function(x, y) {
     Window_Selectable.prototype.initialize.call(this, x, y, width, height);
     this._formationMode = false;
     this._pendingIndex = -1;
-    this.loadImages();
     this.refresh();
 };
 

--- a/js/rpg_windows/Window_Message.js
+++ b/js/rpg_windows/Window_Message.js
@@ -22,6 +22,7 @@ Window_Message.prototype.initialize = function() {
 };
 
 Window_Message.prototype.initMembers = function() {
+    this._imageReservationId = Utils.generateRuntimeId();
     this._background = 0;
     this._positionType = 2;
     this._waitCount = 0;
@@ -251,7 +252,6 @@ Window_Message.prototype.newPage = function(textState) {
 };
 
 Window_Message.prototype.loadMessageFace = function() {
-    this._imageReservationId = this._imageReservationId || Utils.generateRuntimeId();
     this._faceBitmap = ImageManager.reserveFace($gameMessage.faceName(), 0, this._imageReservationId);
 };
 

--- a/js/rpg_windows/Window_Message.js
+++ b/js/rpg_windows/Window_Message.js
@@ -251,11 +251,13 @@ Window_Message.prototype.newPage = function(textState) {
 };
 
 Window_Message.prototype.loadMessageFace = function() {
-    this._faceBitmap = ImageManager.loadFace($gameMessage.faceName());
+    this._imageReservationId = this._imageReservationId || Utils.generateRuntimeId();
+    this._faceBitmap = ImageManager.reserveFace($gameMessage.faceName(), 0, this._imageReservationId);
 };
 
 Window_Message.prototype.drawMessageFace = function() {
     this.drawFace($gameMessage.faceName(), $gameMessage.faceIndex(), 0, 0);
+    ImageManager.releaseReservation(this._imageReservationId);
 };
 
 Window_Message.prototype.newLineX = function() {

--- a/js/rpg_windows/Window_SkillStatus.js
+++ b/js/rpg_windows/Window_SkillStatus.js
@@ -13,7 +13,6 @@ Window_SkillStatus.prototype.constructor = Window_SkillStatus;
 Window_SkillStatus.prototype.initialize = function(x, y, width, height) {
     Window_Base.prototype.initialize.call(this, x, y, width, height);
     this._actor = null;
-    this.reserveFaceImages();
 };
 
 Window_SkillStatus.prototype.setActor = function(actor) {

--- a/js/rpg_windows/Window_SkillStatus.js
+++ b/js/rpg_windows/Window_SkillStatus.js
@@ -18,6 +18,9 @@ Window_SkillStatus.prototype.initialize = function(x, y, width, height) {
 Window_SkillStatus.prototype.setActor = function(actor) {
     if (this._actor !== actor) {
         this._actor = actor;
+        if (actor) {
+            ImageManager.reserveFace(actor.faceName());
+        }
         this.refresh();
     }
 };

--- a/js/rpg_windows/Window_SkillStatus.js
+++ b/js/rpg_windows/Window_SkillStatus.js
@@ -13,14 +13,12 @@ Window_SkillStatus.prototype.constructor = Window_SkillStatus;
 Window_SkillStatus.prototype.initialize = function(x, y, width, height) {
     Window_Base.prototype.initialize.call(this, x, y, width, height);
     this._actor = null;
+    this.reserveFaceImages();
 };
 
 Window_SkillStatus.prototype.setActor = function(actor) {
     if (this._actor !== actor) {
         this._actor = actor;
-        if (actor) {
-            ImageManager.reserveFace(actor.faceName());
-        }
         this.refresh();
     }
 };

--- a/js/rpg_windows/Window_Status.js
+++ b/js/rpg_windows/Window_Status.js
@@ -14,6 +14,7 @@ Window_Status.prototype.initialize = function() {
     var width = Graphics.boxWidth;
     var height = Graphics.boxHeight;
     Window_Selectable.prototype.initialize.call(this, 0, 0, width, height);
+    this._actor = null;
     this.refresh();
     this.activate();
 };
@@ -21,6 +22,9 @@ Window_Status.prototype.initialize = function() {
 Window_Status.prototype.setActor = function(actor) {
     if (this._actor !== actor) {
         this._actor = actor;
+        if (actor) {
+            ImageManager.reserveFace(actor.faceName());
+        }
         this.refresh();
     }
 };

--- a/js/rpg_windows/Window_Status.js
+++ b/js/rpg_windows/Window_Status.js
@@ -15,7 +15,6 @@ Window_Status.prototype.initialize = function() {
     var height = Graphics.boxHeight;
     Window_Selectable.prototype.initialize.call(this, 0, 0, width, height);
     this._actor = null;
-    this.reserveFaceImages();
     this.refresh();
     this.activate();
 };

--- a/js/rpg_windows/Window_Status.js
+++ b/js/rpg_windows/Window_Status.js
@@ -15,6 +15,7 @@ Window_Status.prototype.initialize = function() {
     var height = Graphics.boxHeight;
     Window_Selectable.prototype.initialize.call(this, 0, 0, width, height);
     this._actor = null;
+    this.reserveFaceImages();
     this.refresh();
     this.activate();
 };
@@ -22,9 +23,6 @@ Window_Status.prototype.initialize = function() {
 Window_Status.prototype.setActor = function(actor) {
     if (this._actor !== actor) {
         this._actor = actor;
-        if (actor) {
-            ImageManager.reserveFace(actor.faceName());
-        }
         this.refresh();
     }
 };


### PR DESCRIPTION
Hey, I fixed a lack of some reserveFaces.
For `Window_Status and Window_SkillStatus`, a face image is necessary, but it was not reserved.
This is a bug from the original code, but now is a good opportunity to fix it.
So, I reserved these face images when each scene (`Scene_Status, Scene_Skill`) started.

This is a breaking change because "Now Loading" can occur when the scene starts.
However, in fact it will not happen, because the cache mechanism is LFU,
so the face image will be loaded by `Window_MenuStatus` just before.