### PR TITLE
replace useless ImageManager.isReady() to bitmap.isReady()

### DIFF
--- a/js/rpg_objects/Game_Interpreter.js
+++ b/js/rpg_objects/Game_Interpreter.js
@@ -1290,15 +1290,15 @@ Game_Interpreter.prototype.command281 = function() {
 // Change Tileset
 Game_Interpreter.prototype.command282 = function() {
     var tileset = $dataTilesets[this._params[0]];
-    if(!this._imageReservationId){
+    if(!this._imageReservationId) {
         this._imageReservationId = Utils.generateRuntimeId();
-
-        for (var i = 0; i < tileset.tilesetNames.length; i++) {
-            ImageManager.reserveTileset(tileset.tilesetNames[i], 0, this._imageReservationId);
-        }
     }
 
-    if (ImageManager.isReady()) {
+    var allReady = tileset.tilesetNames.map(function(tilesetName) {
+        return ImageManager.reserveTileset(tilesetName, 0, this._imageReservationId);
+    }, this).every(function(bitmap) {return bitmap.isReady();});
+
+    if (allReady) {
         $gameMap.changeTileset(this._params[0]);
         ImageManager.releaseReservation(this._imageReservationId);
         this._imageReservationId = null;

--- a/js/rpg_objects/Game_Interpreter.js
+++ b/js/rpg_objects/Game_Interpreter.js
@@ -1290,7 +1290,7 @@ Game_Interpreter.prototype.command281 = function() {
 // Change Tileset
 Game_Interpreter.prototype.command282 = function() {
     var tileset = $dataTilesets[this._params[0]];
-    if(!this._imageReservationId) {
+    if(!this._imageReservationId){
         this._imageReservationId = Utils.generateRuntimeId();
     }
 

--- a/js/rpg_sprites/Sprite_Animation.js
+++ b/js/rpg_sprites/Sprite_Animation.js
@@ -140,7 +140,7 @@ Sprite_Animation.prototype.loadBitmaps = function() {
 };
 
 Sprite_Animation.prototype.isReady = function() {
-    return ImageManager.isReady();
+    return this._bitmap1 && this._bitmap1.isReady() && this._bitmap2 && this._bitmap2.isReady();
 };
 
 Sprite_Animation.prototype.createSprites = function() {

--- a/js/rpg_windows/Window_Message.js
+++ b/js/rpg_windows/Window_Message.js
@@ -134,7 +134,7 @@ Window_Message.prototype.updateWait = function() {
 
 Window_Message.prototype.updateLoading = function() {
     if (this._faceBitmap) {
-        if (ImageManager.isReady()) {
+        if (this._faceBitmap.isReady()) {
             this.drawMessageFace();
             this._faceBitmap = null;
             return false;


### PR DESCRIPTION
`ImageManager.isReady()` is sometimes abused.
In Tileset change, animation load, message face change, `ImageManager.isReady()` is used,
but it's enough if only the bitmap they use is ready.

Using `ImageManager.isReady()` makes it very inconvenient because blocking will occur even if unrelated bitmap isn't prepared.
So, I replaced them to `bitmap.isReady()`.