### PR TITLE
add ImageManager.clearRequest() when changing Scene_Map to Scene_Battle

### DIFF
--- a/js/rpg_scenes/Scene_Map.js
+++ b/js/rpg_scenes/Scene_Map.js
@@ -110,6 +110,8 @@ Scene_Map.prototype.terminate = function() {
         this._spriteset.update();
         this._mapNameWindow.hide();
         SceneManager.snapForBackground();
+    } else {
+        ImageManager.clearRequest();
     }
 
     if (SceneManager.isNextScene(Scene_Map)) {


### PR DESCRIPTION
Scene_Battle -> any Scene (including Scene_Map)
Scene_Map -> Scene_Map

above case, requestQueue is cleared. So, it would be nice to clear request below case.

Scene_Map -> Scene_Battle