### PR TITLE
extend the limit font load error

### DIFF
--- a/js/rpg_scenes/Scene_Boot.js
+++ b/js/rpg_scenes/Scene_Boot.js
@@ -52,7 +52,7 @@ Scene_Boot.prototype.isGameFontLoaded = function() {
         return true;
     } else if (!Graphics.canUseCssFontLoading()){
         var elapsed = Date.now() - this._startDate;
-        if (elapsed >= 20000) {
+        if (elapsed >= 60000) {
             throw new Error('Failed to load GameFont');
         }
     }


### PR DESCRIPTION
Browsers that don't support CSS font loading fails to load fonts in 20 seconds, but this is too short. Let's extend it to 60 seconds.