### PR TITLE
chrome treats touchstart/touchmove event as passive

### DIFF
--- a/js/rpg_core/TouchInput.js
+++ b/js/rpg_core/TouchInput.js
@@ -250,12 +250,13 @@ Object.defineProperty(TouchInput, 'date', {
  * @private
  */
 TouchInput._setupEventHandlers = function() {
+    var isSupportPassive = Utils.isSupportPassive();
     document.addEventListener('mousedown', this._onMouseDown.bind(this));
     document.addEventListener('mousemove', this._onMouseMove.bind(this));
     document.addEventListener('mouseup', this._onMouseUp.bind(this));
     document.addEventListener('wheel', this._onWheel.bind(this));
-    document.addEventListener('touchstart', this._onTouchStart.bind(this));
-    document.addEventListener('touchmove', this._onTouchMove.bind(this));
+    document.addEventListener('touchstart', this._onTouchStart.bind(this), isSupportPassive ? {passive: false} : false);
+    document.addEventListener('touchmove', this._onTouchMove.bind(this), isSupportPassive ? {passive: false} : false);
     document.addEventListener('touchend', this._onTouchEnd.bind(this));
     document.addEventListener('touchcancel', this._onTouchCancel.bind(this));
     document.addEventListener('pointerdown', this._onPointerDown.bind(this));

--- a/js/rpg_core/Utils.js
+++ b/js/rpg_core/Utils.js
@@ -132,3 +132,26 @@ Utils._id = 1;
 Utils.generateRuntimeId = function(){
     return Utils._id++;
 };
+
+Utils._supportPassiveEvent = null;
+/**
+ * Test this browser support passive event feature
+ * 
+ * @static
+ * @method isSupportPassiveEvent
+ * @return {Boolean} this browser support passive event or not
+ */
+Utils.isSupportPassiveEvent = function() {
+    if (typeof Utils._supportPassiveEvent === "boolean") {
+        return Utils._supportPassiveEvent;
+    }
+    // test support passive event
+    // https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+    var passive = false;
+    var options = Object.defineProperty({}, "passive", {
+        get() { passive = true; }
+    });
+    window.addEventListener("test", null, options);
+    Utils._supportPassiveEvent = passive;
+    return passive;
+}

--- a/js/rpg_core/Utils.js
+++ b/js/rpg_core/Utils.js
@@ -149,7 +149,7 @@ Utils.isSupportPassiveEvent = function() {
     // https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
     var passive = false;
     var options = Object.defineProperty({}, "passive", {
-        get() { passive = true; }
+        get: function() { passive = true; }
     });
     window.addEventListener("test", null, options);
     Utils._supportPassiveEvent = passive;


### PR DESCRIPTION
### Problem

Chrome 56+ treats touchstart/touchmove event as passive default.
So, `preventDefault()` has no effect at passive event.

https://www.chromestatus.com/feature/5093566007214080

### Solve

Test this browser support passive, and set `passive: false` if support.

