### PR TITLE
fix don't show loading error when images encrypted

### DIFF
--- a/js/rpg_core/Decrypter.js
+++ b/js/rpg_core/Decrypter.js
@@ -39,6 +39,14 @@ Decrypter.decryptImg = function(url, bitmap) {
             bitmap._image.onerror = bitmap._loader || Bitmap.prototype._onError.bind(bitmap);
         }
     };
+
+    requestFile.onerror = function () {
+        if (bitmap._loader) {
+            bitmap._loader();
+        } else {
+            bitmap._onError();
+        }
+    };
 };
 
 Decrypter.decryptHTML5Audio = function(url, bgm, pos) {


### PR DESCRIPTION
Loading error is important for players and creators, but it's not shown when images encrypted. 😖 
Fixed