### PR TITLE
Added mirrorX and mirrorY property

### DIFF
--- a/js/rpg_core/Sprite.js
+++ b/js/rpg_core/Sprite.js
@@ -122,6 +122,40 @@ Object.defineProperty(Sprite.prototype, 'opacity', {
 });
 
 /**
+ * Flip the sprite on the horizontal axis.
+ *
+ * @property mirrorX
+ * @type Boolean
+ */
+Object.defineProperty(Sprite.prototype, 'mirrorX', {
+    set: function(value){
+        if(value === true){
+            this.scale.x = -1;
+        } else {
+            this.scale.x = 1;
+        }
+    },
+    configurable : true
+});
+
+/**
+ * Flip the sprite on the vertical axis.
+ *
+ * @property mirrorY
+ * @type Boolean
+ */
+Object.defineProperty(Sprite.prototype, 'mirrorY', {
+    set: function(value) {
+        if(value === true){
+            this.scale.y = -1;
+        } else {
+            this.scale.y = 1;
+        }
+    },
+    configurable: true
+});
+
+/**
  * Updates the sprite for each frame.
  *
  * @method update

--- a/js/rpg_core/Sprite.js
+++ b/js/rpg_core/Sprite.js
@@ -128,6 +128,13 @@ Object.defineProperty(Sprite.prototype, 'opacity', {
  * @type Boolean
  */
 Object.defineProperty(Sprite.prototype, 'mirrorX', {
+    get: function(){
+        if(this.scale.x === -1){
+            return true;
+        } else {
+            return false;
+        }
+    },
     set: function(value){
         if(value === true){
             this.scale.x = -1;
@@ -145,6 +152,13 @@ Object.defineProperty(Sprite.prototype, 'mirrorX', {
  * @type Boolean
  */
 Object.defineProperty(Sprite.prototype, 'mirrorY', {
+    get: function(){
+        if(scale.y === -1){
+            return true;
+        } else {
+            return false;
+        }
+    },
     set: function(value) {
         if(value === true){
             this.scale.y = -1;


### PR DESCRIPTION
We know that technically we can flip the pictures in MV with the sprite.scale.axis = -1; although it's not really intuitive for some peoples so I added a more easy to use features.
Since it's doesn't overwrite the method. I think it's fine to implement it?