### PR TITLE
improve Debug_ReportMemory.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "copy:corescripts": "cpx ./dist/*.js ./game/js/",
     "copy:libs": "cpx ./js/libs/*.js ./game/js/libs/",
     "copy:main": "cpx ./js/main.js ./game/js/",
+    "copy:plugins": "cpx ./plugins/*.js ./game/js/plugins/",
     "copy:template": "cpx ./template/**/* ./game/",
     "copy": "run-p copy:*",
     "copy-all": "node copy-all.js ./corescript",

--- a/plugins/Debug_ReportMemory.js
+++ b/plugins/Debug_ReportMemory.js
@@ -4,8 +4,11 @@
  *
  * @help
  * This plugin shows memory related usages.
- * size: size in MPixel
- * totalCount: count of Bitmaps
+ * usedSize: the total size of the image actually being used in the game now.
+ *           If this value exceeds about 150MPix, some mobile devices will crash.
+ * cachedSize: cached size in MPixel
+ * cacheLimit: the upper limit of cached size (It doesn't matter if cachedSize exceeds just a little)
+ * totalCount: count of cached Bitmaps
  * requestCount: count of requested Bitmaps
  * reservedCount: count of reserved Bitmaps
  *
@@ -13,6 +16,7 @@
  * If you find that It increases gradually after reaching limit, Please report to team!!
  *
  * @param Max Pixels In MPix
+ * @desc decide the value of "cacheLimit" displayed in the upper right
  * @default 20
  *
  */
@@ -23,8 +27,11 @@
  *
  * @help
  * メモリ使用量を表示します。
- * size: 使用量です。単位はMPixelです。
- * totalCount: Bitmapの数です
+ * usedSize: 今ゲーム中で実際に使用されている画像の合計サイズです。
+ * 　　　　　この値が150MPix辺りを越えると、一部モバイルデバイスがクラッシュします。
+ * cachedSize: キャッシュされている使用量です。単位はMPixelです。
+ * cacheLimit: キャッシュできる上限値です。cachedSizeを越えることもありますが、少しだけなら正常です。
+ * totalCount: キャッシュされているBitmapの数です
  * requestCount: 先行読み込みの数です
  * reservedCount: 予約の数です
  *
@@ -32,13 +39,14 @@
  * 続ける場合は、教えていただけると幸いです。
  *
  * @param Max Pixels In MPix
+ * @desc 右上に表示されているcacheLimitの値を決めます
  * @default 20
  *
  */
 
 (function(){
     var parameters = PluginManager.parameters('Debug_ReportMemory');
-    var pixels = +parameters['Max Pixels In MPix'] || 20;
+    var pixels = toNumber(parameters['Max Pixels In MPix'], 20);
 
     ImageCache.limit = pixels * 1000 * 1000;
 
@@ -49,13 +57,36 @@
     div.style.top = 0;
     document.body.appendChild(div);
 
+    function toNumber(str, def) {
+        return isNaN(str) ? def : +(str || def);
+    }
+
+    function toMPix(size) {
+        return Math.floor(size / 1000) / 1000 + 'MPix';
+    }
+
+    function usedSize(item) {
+        var totalSize = 0;
+        if (item && item.bitmap) {
+            totalSize += item.bitmap.width * item.bitmap.height;
+        }
+        if (item && item.children) {
+            totalSize += item.children.reduce(function(sum, child) {
+                return sum + usedSize(child);
+            }, 0);
+        }
+        return totalSize;
+    }
+
     function updateInfo(){
-        var content = 'size: ' + Math.floor(ImageManager._imageCache._getSize()/1000)/1000 + 'MPix<br>';
+        var content = 'usedSize: ' + toMPix(usedSize(SceneManager._scene)) + '<br>';
+        content += 'cachedSize: ' + toMPix(ImageManager._imageCache._getSize()) + '<br>';
+        content += '(cacheLimit: ' + pixels + 'MPix)<br>';
         content += 'totalCount: ' + ImageManager._imageCache._countBitmap() + '<br>';
         content += 'requestCount: ' + ImageManager._imageCache._countRequest() + '<br>';
         content += 'reservedCount: ' + ImageManager._imageCache._countReserved() + '<br>';
 
-        div.innerHTML = content;
+        if (div.innerHTML !== content) div.innerHTML = content;
         div.style.zIndex = 11;
     }
 

--- a/plugins/Debug_ReportMemory.js
+++ b/plugins/Debug_ReportMemory.js
@@ -30,7 +30,7 @@
  * usedSize: 今ゲーム中で実際に使用されている画像の合計サイズです。
  * 　　　　　この値が150MPix辺りを越えると、一部モバイルデバイスがクラッシュします。
  * cachedSize: キャッシュされている使用量です。単位はMPixelです。
- * cacheLimit: キャッシュできる上限値です。cachedSizeを越えることもありますが、少しだけなら正常です。
+ * cacheLimit: キャッシュできる上限値です。cachedSizeの方が上回ることもありますが、少しだけなら正常です。
  * totalCount: キャッシュされているBitmapの数です
  * requestCount: 先行読み込みの数です
  * reservedCount: 予約の数です

--- a/plugins/Debug_ReportMemory.js
+++ b/plugins/Debug_ReportMemory.js
@@ -5,7 +5,7 @@
  * @help
  * This plugin shows memory related usages.
  * usedSize: the total size of the image actually being used in the game now.
- *           If this value exceeds about 150MPix, some mobile devices will crash.
+ *           If this value exceeds about 50MPix, some mobile devices may crash.
  * cachedSize: cached size in MPixel
  * cacheLimit: the upper limit of cached size (It doesn't matter if cachedSize exceeds just a little)
  * totalCount: count of cached Bitmaps
@@ -28,7 +28,7 @@
  * @help
  * メモリ使用量を表示します。
  * usedSize: 今ゲーム中で実際に使用されている画像の合計サイズです。
- * 　　　　　この値が150MPix辺りを越えると、一部モバイルデバイスがクラッシュします。
+ * 　　　　　この値が50MPix辺りを越えると、一部モバイルデバイスがクラッシュする可能性があります。
  * cachedSize: キャッシュされている使用量です。単位はMPixelです。
  * cacheLimit: キャッシュできる上限値です。cachedSizeの方が上回ることもありますが、少しだけなら正常です。
  * totalCount: キャッシュされているBitmapの数です


### PR DESCRIPTION
I improved this plugin!
`usedSize` is the total size of images actually being used in the game just now.
`cachedSize` is the total size of cached images.
When `usedSize` exceeds about 150MPix, some mobile devices will crash by out of memory!

P.S.
Changed the build script to copy `plugins` to `/game/js/plguins`.