### PR TITLE
add basic plugin for manipulating parameters

### DIFF
--- a/plugins/Community_Basic.js
+++ b/plugins/Community_Basic.js
@@ -1,0 +1,86 @@
+/*:
+ * @plugindesc Basic plugin for manipulating important parameters..
+ * @author RM CoreScript team
+ *
+ * @param cacheLimit
+ * @desc The upper limit of images' cached size (MPixel)
+ * @default 20
+ *
+ * @param screenWidth
+ * @desc The resolution of screen width
+ * @default 816
+ *
+ * @param screenHeight
+ * @desc The resolution of screen height
+ * @default 624
+ *
+ * @param renderingMode
+ * @desc The rendering mode (canvas/webgl/auto)
+ * @default auto
+ *
+ * @param alwaysDash
+ * @desc The initial value whether the player always dashes (on/off)
+ * @default off
+ */
+
+/*:ja
+ * @plugindesc 基本的なパラメーターを設定するプラグインです。
+ * @author RM CoreScript team
+ *
+ * @param cacheLimit
+ * @desc 画像のメモリへのキャッシュの上限値 (MPix)
+ * @default 20
+ *
+ * @param screenWidth
+ * @desc 画面サイズの幅
+ * @default 816
+ *
+ * @param screenHeight
+ * @desc 画面サイズの高さ
+ * @default 624
+ *
+ * @param renderingMode
+ * @desc レンダリングモード (canvas/webgl/auto)
+ * @default auto
+ *
+ * @param alwaysDash
+ * @desc プレイヤーが常時ダッシュするかどうかの初期値 (on/off)
+ * @default off
+ */
+
+(function() {
+    function toNumber(str, def) {
+        return isNaN(str) ? def : +(str || def);
+    }
+
+    var parameters = PluginManager.parameters('Community_Basic');
+    var cacheLimit = toNumber(parameters['cacheLimit'], 20);
+    var screenWidth = toNumber(parameters['screenWidth'], 816);
+    var screenHeight = toNumber(parameters['screenHeight'], 624);
+    var renderingMode = parameters['renderingMode'].toLowerCase();
+    var alwaysDash = parameters['alwaysDash'].toLowerCase() === 'on';
+
+    ImageCache.limit = cacheLimit * 1000 * 1000;
+    SceneManager._screenWidth = screenWidth;
+    SceneManager._screenHeight = screenHeight;
+    SceneManager._boxWidth = screenWidth;
+    SceneManager._boxHeight = screenHeight;
+
+    SceneManager.preferableRendererType = function() {
+        if (Utils.isOptionValid('canvas') || renderingMode === 'canvas') {
+            return 'canvas';
+        } else if (Utils.isOptionValid('webgl') || renderingMode === 'webgl') {
+            return 'webgl';
+        } else {
+            return 'auto';
+        }
+    };
+
+    var _ConfigManager_applyData = ConfigManager.applyData;
+    ConfigManager.applyData = function(config) {
+        _ConfigManager_applyData.apply(this, arguments);
+        if (config['alwaysDash'] === undefined) {
+            this.alwaysDash = alwaysDash;
+        }
+    };
+})();

--- a/plugins/Community_Basic.js
+++ b/plugins/Community_Basic.js
@@ -67,9 +67,13 @@
     SceneManager._boxHeight = screenHeight;
 
     SceneManager.preferableRendererType = function() {
-        if (Utils.isOptionValid('canvas') || renderingMode === 'canvas') {
+        if (Utils.isOptionValid('canvas')) {
             return 'canvas';
-        } else if (Utils.isOptionValid('webgl') || renderingMode === 'webgl') {
+        } else if (Utils.isOptionValid('webgl')) {
+            return 'webgl';
+        } else if (renderingMode === 'canvas') {
+            return 'canvas';
+        } else if (renderingMode === 'webgl') {
             return 'webgl';
         } else {
             return 'auto';

--- a/plugins/Debug_ReportMemory.js
+++ b/plugins/Debug_ReportMemory.js
@@ -47,6 +47,13 @@
 (function(){
     var parameters = PluginManager.parameters('Debug_ReportMemory');
     var pixels = toNumber(parameters['Max Pixels In MPix'], 20);
+    var communityPixels = PluginManager.parameters('Community_Basic')['cacheLimit'];
+
+    if (communityPixels) {
+        pixels = toNumber(communityPixels, 20);
+        console.log('Community_Basic plugin has been installed, so it overwrites the setting value of cacheLimit. ' +
+        'cacheLimit: ' + pixels + 'MPix');
+    }
 
     ImageCache.limit = pixels * 1000 * 1000;
 


### PR DESCRIPTION
This plugin can manipulate parameters below.

- The upper limit of images' cached size (MPixel)
- The screen resolution
- The rendering mode (canvas/webgl/auto)
- The initial value whether the player always dashes (on/off)