### PR TITLE
fix typo in fullscreen api

### DIFF
--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -1199,9 +1199,10 @@ Graphics._switchFullScreen = function() {
  * @private
  */
 Graphics._isFullScreen = function() {
-    return ((document.fullscreenElement && document.fullscreenElement !== null) ||
-            (!document.mozFullScreen && !document.webkitFullscreenElement &&
-             !document.msFullscreenElement));
+    return document.fullscreenElement ||
+           document.mozFullScreen || 
+           document.webkitFullscreenElement ||
+           document.msFullscreenElement;
 };
 
 /**

--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -1186,9 +1186,9 @@ Graphics._switchStretchMode = function() {
  */
 Graphics._switchFullScreen = function() {
     if (this._isFullScreen()) {
-        this._requestFullScreen();
-    } else {
         this._cancelFullScreen();
+    } else {
+        this._requestFullScreen();
     }
 };
 

--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -1228,7 +1228,7 @@ Graphics._requestFullScreen = function() {
  * @private
  */
 Graphics._cancelFullScreen = function() {
-    if (document.fullscreenElement) { 
+    if (document.exitFullscreen) { 
         document.exitFullscreen();
     } else if (document.mozCancelFullScreen) {
         document.mozCancelFullScreen();

--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -1199,7 +1199,7 @@ Graphics._switchFullScreen = function() {
  * @private
  */
 Graphics._isFullScreen = function() {
-    return ((document.fullScreenElement && document.fullScreenElement !== null) ||
+    return ((document.fullscreenElement && document.fullscreenElement !== null) ||
             (!document.mozFullScreen && !document.webkitFullscreenElement &&
              !document.msFullscreenElement));
 };
@@ -1211,8 +1211,8 @@ Graphics._isFullScreen = function() {
  */
 Graphics._requestFullScreen = function() {
     var element = document.body;
-    if (element.requestFullScreen) {
-        element.requestFullScreen();
+    if (element.requestFullscreen) {
+        element.requestFullscreen();
     } else if (element.mozRequestFullScreen) {
         element.mozRequestFullScreen();
     } else if (element.webkitRequestFullScreen) {
@@ -1228,8 +1228,8 @@ Graphics._requestFullScreen = function() {
  * @private
  */
 Graphics._cancelFullScreen = function() {
-    if (document.cancelFullScreen) {
-        document.cancelFullScreen();
+    if (document.cancelFullscreen) {
+        document.cancelFullscreen();
     } else if (document.mozCancelFullScreen) {
         document.mozCancelFullScreen();
     } else if (document.webkitCancelFullScreen) {

--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -1228,8 +1228,8 @@ Graphics._requestFullScreen = function() {
  * @private
  */
 Graphics._cancelFullScreen = function() {
-    if (document.cancelFullscreen) {
-        document.cancelFullscreen();
+    if (document.fullscreenElement) { 
+        document.exitFullscreen();
     } else if (document.mozCancelFullScreen) {
         document.mozCancelFullScreen();
     } else if (document.webkitCancelFullScreen) {


### PR DESCRIPTION
the right spelling is using `screen` not `Screen` according to MDN:

https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenElement
https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen
https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen