### PR TITLE
remove duplicated _renderWebGL method in TilingSprite.js, fix  #123

### DIFF
--- a/js/rpg_core/TilingSprite.js
+++ b/js/rpg_core/TilingSprite.js
@@ -52,23 +52,6 @@ TilingSprite.prototype._renderCanvas = function(renderer) {
 };
 
 /**
- * @method _renderWebGL
- * @param {Object} renderer
- * @private
- */
-TilingSprite.prototype._renderWebGL = function(renderer) {
-    if (this._bitmap) {
-        this._bitmap.touch();
-    }
-    if (this.texture.frame.width > 0 && this.texture.frame.height > 0) {
-        if (this._bitmap) {
-            this._bitmap.checkDirty();
-        }
-        this._renderWebGL_PIXI(renderer);
-    }
-};
-
-/**
  * The image for the tiling sprite.
  *
  * @property bitmap


### PR DESCRIPTION
remove duplicated _renderWebGL().
running `npm test` is successful and I don't see any error when playing sample game (only test in title screen tough)