### PR TITLE
drawItem()修正

### DIFF
--- a/js/rpg_objects/Game_Interpreter.js
+++ b/js/rpg_objects/Game_Interpreter.js
@@ -1740,129 +1740,129 @@ Game_Interpreter.prototype.pluginCommand = function(command, args) {
     // to be overridden by plugins
 };
 
-Game_Interpreter.requestImageForCommand =function(command){
-    var params = command.parameters;
-    switch(command.code){
-        // Show Text
-        case 101:
-            ImageManager.requestFace(params[0]);
-            break;
-
-        // Common Event
-        case 117:
-            var commonEvent = $dataCommonEvents[params[0]];
-            if (commonEvent) {
-                if (!commonList) {
-                    commonList = [];
-                }
-                if (!commonList.contains(params[0])) {
-                    commonList.push(params[0]);
-                    Game_Interpreter.requestImages(commonEvent.list, commonList);
-                }
-            }
-            break;
-
-        // Change Party Member
-        case 129:
-            var actor = $gameActors.actor(params[0]);
-            if (actor && params[1] === 0) {
-                var name = actor.characterName();
-                ImageManager.requestCharacter(name);
-            }
-            break;
-
-        // Set Movement Route
-        case 205:
-            if(params[1]){
-                params[1].list.forEach(function(command){
-                    var params = command.parameters;
-                    if(command.code === Game_Character.ROUTE_CHANGE_IMAGE){
-                        ImageManager.requestCharacter(params[0]);
-                    }
-                });
-            }
-            break;
-
-        // Show Animation, Show Battle Animation
-        case 212: case 337:
-            if(params[1]) {
-                var animation = $dataAnimations[params[1]];
-                var name1 = animation.animation1Name;
-                var name2 = animation.animation2Name;
-                var hue1 = animation.animation1Hue;
-                var hue2 = animation.animation2Hue;
-                ImageManager.requestAnimation(name1, hue1);
-                ImageManager.requestAnimation(name2, hue2);
-            }
-            break;
-
-        // Change Player Followers
-        case 216:
-            if (params[0] === 0) {
-                $gamePlayer.followers().forEach(function(follower) {
-                    var name = follower.characterName();
-                    ImageManager.requestCharacter(name);
-                });
-            }
-            break;
-
-        // Show Picture
-        case 231:
-            ImageManager.requestPicture(params[1]);
-            break;
-
-        // Change Tileset
-        case 282:
-            var tileset = $dataTilesets[params[0]];
-            tileset.tilesetNames.forEach(function(tilesetName){
-                ImageManager.requestTileset(tilesetName);
-            });
-            break;
-
-        // Change Battle Back
-        case 283:
-            if ($gameParty.inBattle()) {
-                ImageManager.requestBattleback1(params[0]);
-                ImageManager.requestBattleback2(params[1]);
-            }
-            break;
-
-        // Change Parallax
-        case 284:
-            if (!$gameParty.inBattle()) {
-                ImageManager.requestParallax(params[0]);
-            }
-            break;
-
-        // Change Actor Images
-        case 322:
-            ImageManager.requestCharacter(params[1]);
-            ImageManager.requestFace(params[3]);
-            ImageManager.requestSvActor(params[5]);
-            break;
-
-        // Change Vehicle Image
-        case 323:
-            var vehicle = $gameMap.vehicle(params[0]);
-            if(vehicle){
-                ImageManager.requestCharacter(params[1]);
-            }
-            break;
-
-        // Enemy Transform
-        case 336:
-            var enemy = $dataEnemies[params[1]];
-            var name = enemy.battlerName;
-            var hue = enemy.battlerHue;
-            if ($gameSystem.isSideView()) {
-                ImageManager.requestSvEnemy(name, hue);
-            } else {
-                ImageManager.requestEnemy(name, hue);
-            }
-            break;
-    }
-};
 Game_Interpreter.requestImages = function(list, commonList){
     if(!list) return;
-    list.forEach(Game_Interpreter.requestImageForCommand);
+
+    list.forEach(function(command){
+        var params = command.parameters;
+        switch(command.code){
+            // Show Text
+            case 101:
+                ImageManager.requestFace(params[0]);
+                break;
+
+            // Common Event
+            case 117:
+                var commonEvent = $dataCommonEvents[params[0]];
+                if (commonEvent) {
+                    if (!commonList) {
+                        commonList = [];
+                    }
+                    if (!commonList.contains(params[0])) {
+                        commonList.push(params[0]);
+                        Game_Interpreter.requestImages(commonEvent.list, commonList);
+                    }
+                }
+                break;
+
+            // Change Party Member
+            case 129:
+                var actor = $gameActors.actor(params[0]);
+                if (actor && params[1] === 0) {
+                    var name = actor.characterName();
+                    ImageManager.requestCharacter(name);
+                }
+                break;
+
+            // Set Movement Route
+            case 205:
+                if(params[1]){
+                    params[1].list.forEach(function(command){
+                        var params = command.parameters;
+                        if(command.code === Game_Character.ROUTE_CHANGE_IMAGE){
+                            ImageManager.requestCharacter(params[0]);
+                        }
+                    });
+                }
+                break;
+
+            // Show Animation, Show Battle Animation
+            case 212: case 337:
+                if(params[1]) {
+                    var animation = $dataAnimations[params[1]];
+                    var name1 = animation.animation1Name;
+                    var name2 = animation.animation2Name;
+                    var hue1 = animation.animation1Hue;
+                    var hue2 = animation.animation2Hue;
+                    ImageManager.requestAnimation(name1, hue1);
+                    ImageManager.requestAnimation(name2, hue2);
+                }
+                break;
+
+            // Change Player Followers
+            case 216:
+                if (params[0] === 0) {
+                    $gamePlayer.followers().forEach(function(follower) {
+                        var name = follower.characterName();
+                        ImageManager.requestCharacter(name);
+                    });
+                }
+                break;
+
+            // Show Picture
+            case 231:
+                ImageManager.requestPicture(params[1]);
+                break;
+
+            // Change Tileset
+            case 282:
+                var tileset = $dataTilesets[params[0]];
+                tileset.tilesetNames.forEach(function(tilesetName){
+                    ImageManager.requestTileset(tilesetName);
+                });
+                break;
+
+            // Change Battle Back
+            case 283:
+                if ($gameParty.inBattle()) {
+                    ImageManager.requestBattleback1(params[0]);
+                    ImageManager.requestBattleback2(params[1]);
+                }
+                break;
+
+            // Change Parallax
+            case 284:
+                if (!$gameParty.inBattle()) {
+                    ImageManager.requestParallax(params[0]);
+                }
+                break;
+
+            // Change Actor Images
+            case 322:
+                ImageManager.requestCharacter(params[1]);
+                ImageManager.requestFace(params[3]);
+                ImageManager.requestSvActor(params[5]);
+                break;
+
+            // Change Vehicle Image
+            case 323:
+                var vehicle = $gameMap.vehicle(params[0]);
+                if(vehicle){
+                    ImageManager.requestCharacter(params[1]);
+                }
+                break;
+
+            // Enemy Transform
+            case 336:
+                var enemy = $dataEnemies[params[1]];
+                var name = enemy.battlerName;
+                var hue = enemy.battlerHue;
+                if ($gameSystem.isSideView()) {
+                    ImageManager.requestSvEnemy(name, hue);
+                } else {
+                    ImageManager.requestEnemy(name, hue);
+                }
+                break;
+        }
+    });
 };

--- a/js/rpg_objects/Game_Interpreter.js
+++ b/js/rpg_objects/Game_Interpreter.js
@@ -1862,7 +1862,6 @@ Game_Interpreter.requestImageForCommand =function(command){
             break;
     }
 };
-
 Game_Interpreter.requestImages = function(list, commonList){
     if(!list) return;
     list.forEach(Game_Interpreter.requestImageForCommand);

--- a/js/rpg_objects/Game_Interpreter.js
+++ b/js/rpg_objects/Game_Interpreter.js
@@ -1740,129 +1740,130 @@ Game_Interpreter.prototype.pluginCommand = function(command, args) {
     // to be overridden by plugins
 };
 
+Game_Interpreter.requestImagesForCommand　=function(command){
+    var params = command.parameters;
+    switch(command.code){
+        // Show Text
+        case 101:
+            ImageManager.requestFace(params[0]);
+            break;
+
+        // Common Event
+        case 117:
+            var commonEvent = $dataCommonEvents[params[0]];
+            if (commonEvent) {
+                if (!commonList) {
+                    commonList = [];
+                }
+                if (!commonList.contains(params[0])) {
+                    commonList.push(params[0]);
+                    Game_Interpreter.requestImages(commonEvent.list, commonList);
+                }
+            }
+            break;
+
+        // Change Party Member
+        case 129:
+            var actor = $gameActors.actor(params[0]);
+            if (actor && params[1] === 0) {
+                var name = actor.characterName();
+                ImageManager.requestCharacter(name);
+            }
+            break;
+
+        // Set Movement Route
+        case 205:
+            if(params[1]){
+                params[1].list.forEach(function(command){
+                    var params = command.parameters;
+                    if(command.code === Game_Character.ROUTE_CHANGE_IMAGE){
+                        ImageManager.requestCharacter(params[0]);
+                    }
+                });
+            }
+            break;
+
+        // Show Animation, Show Battle Animation
+        case 212: case 337:
+            if(params[1]) {
+                var animation = $dataAnimations[params[1]];
+                var name1 = animation.animation1Name;
+                var name2 = animation.animation2Name;
+                var hue1 = animation.animation1Hue;
+                var hue2 = animation.animation2Hue;
+                ImageManager.requestAnimation(name1, hue1);
+                ImageManager.requestAnimation(name2, hue2);
+            }
+            break;
+
+        // Change Player Followers
+        case 216:
+            if (params[0] === 0) {
+                $gamePlayer.followers().forEach(function(follower) {
+                    var name = follower.characterName();
+                    ImageManager.requestCharacter(name);
+                });
+            }
+            break;
+
+        // Show Picture
+        case 231:
+            ImageManager.requestPicture(params[1]);
+            break;
+
+        // Change Tileset
+        case 282:
+            var tileset = $dataTilesets[params[0]];
+            tileset.tilesetNames.forEach(function(tilesetName){
+                ImageManager.requestTileset(tilesetName);
+            });
+            break;
+
+        // Change Battle Back
+        case 283:
+            if ($gameParty.inBattle()) {
+                ImageManager.requestBattleback1(params[0]);
+                ImageManager.requestBattleback2(params[1]);
+            }
+            break;
+
+        // Change Parallax
+        case 284:
+            if (!$gameParty.inBattle()) {
+                ImageManager.requestParallax(params[0]);
+            }
+            break;
+
+        // Change Actor Images
+        case 322:
+            ImageManager.requestCharacter(params[1]);
+            ImageManager.requestFace(params[3]);
+            ImageManager.requestSvActor(params[5]);
+            break;
+
+        // Change Vehicle Image
+        case 323:
+            var vehicle = $gameMap.vehicle(params[0]);
+            if(vehicle){
+                ImageManager.requestCharacter(params[1]);
+            }
+            break;
+
+        // Enemy Transform
+        case 336:
+            var enemy = $dataEnemies[params[1]];
+            var name = enemy.battlerName;
+            var hue = enemy.battlerHue;
+            if ($gameSystem.isSideView()) {
+                ImageManager.requestSvEnemy(name, hue);
+            } else {
+                ImageManager.requestEnemy(name, hue);
+            }
+            break;
+    }
+};
 Game_Interpreter.requestImages = function(list, commonList){
     if(!list) return;
 
-    list.forEach(function(command){
-        var params = command.parameters;
-        switch(command.code){
-            // Show Text
-            case 101:
-                ImageManager.requestFace(params[0]);
-                break;
-
-            // Common Event
-            case 117:
-                var commonEvent = $dataCommonEvents[params[0]];
-                if (commonEvent) {
-                    if (!commonList) {
-                        commonList = [];
-                    }
-                    if (!commonList.contains(params[0])) {
-                        commonList.push(params[0]);
-                        Game_Interpreter.requestImages(commonEvent.list, commonList);
-                    }
-                }
-                break;
-
-            // Change Party Member
-            case 129:
-                var actor = $gameActors.actor(params[0]);
-                if (actor && params[1] === 0) {
-                    var name = actor.characterName();
-                    ImageManager.requestCharacter(name);
-                }
-                break;
-
-            // Set Movement Route
-            case 205:
-                if(params[1]){
-                    params[1].list.forEach(function(command){
-                        var params = command.parameters;
-                        if(command.code === Game_Character.ROUTE_CHANGE_IMAGE){
-                            ImageManager.requestCharacter(params[0]);
-                        }
-                    });
-                }
-                break;
-
-            // Show Animation, Show Battle Animation
-            case 212: case 337:
-                if(params[1]) {
-                    var animation = $dataAnimations[params[1]];
-                    var name1 = animation.animation1Name;
-                    var name2 = animation.animation2Name;
-                    var hue1 = animation.animation1Hue;
-                    var hue2 = animation.animation2Hue;
-                    ImageManager.requestAnimation(name1, hue1);
-                    ImageManager.requestAnimation(name2, hue2);
-                }
-                break;
-
-            // Change Player Followers
-            case 216:
-                if (params[0] === 0) {
-                    $gamePlayer.followers().forEach(function(follower) {
-                        var name = follower.characterName();
-                        ImageManager.requestCharacter(name);
-                    });
-                }
-                break;
-
-            // Show Picture
-            case 231:
-                ImageManager.requestPicture(params[1]);
-                break;
-
-            // Change Tileset
-            case 282:
-                var tileset = $dataTilesets[params[0]];
-                tileset.tilesetNames.forEach(function(tilesetName){
-                    ImageManager.requestTileset(tilesetName);
-                });
-                break;
-
-            // Change Battle Back
-            case 283:
-                if ($gameParty.inBattle()) {
-                    ImageManager.requestBattleback1(params[0]);
-                    ImageManager.requestBattleback2(params[1]);
-                }
-                break;
-
-            // Change Parallax
-            case 284:
-                if (!$gameParty.inBattle()) {
-                    ImageManager.requestParallax(params[0]);
-                }
-                break;
-
-            // Change Actor Images
-            case 322:
-                ImageManager.requestCharacter(params[1]);
-                ImageManager.requestFace(params[3]);
-                ImageManager.requestSvActor(params[5]);
-                break;
-
-            // Change Vehicle Image
-            case 323:
-                var vehicle = $gameMap.vehicle(params[0]);
-                if(vehicle){
-                    ImageManager.requestCharacter(params[1]);
-                }
-                break;
-
-            // Enemy Transform
-            case 336:
-                var enemy = $dataEnemies[params[1]];
-                var name = enemy.battlerName;
-                var hue = enemy.battlerHue;
-                if ($gameSystem.isSideView()) {
-                    ImageManager.requestSvEnemy(name, hue);
-                } else {
-                    ImageManager.requestEnemy(name, hue);
-                }
-                break;
-        }
-    });
+    list.forEach(Game_Interpreter.requestImagesForCommand);
 };

--- a/js/rpg_objects/Game_Interpreter.js
+++ b/js/rpg_objects/Game_Interpreter.js
@@ -1864,6 +1864,5 @@ Game_Interpreter.requestImagesForCommand　=function(command){
 };
 Game_Interpreter.requestImages = function(list, commonList){
     if(!list) return;
-
     list.forEach(Game_Interpreter.requestImagesForCommand);
 };

--- a/js/rpg_objects/Game_Interpreter.js
+++ b/js/rpg_objects/Game_Interpreter.js
@@ -1740,129 +1740,130 @@ Game_Interpreter.prototype.pluginCommand = function(command, args) {
     // to be overridden by plugins
 };
 
+Game_Interpreter.requestImageForCommand =function(command){
+    var params = command.parameters;
+    switch(command.code){
+        // Show Text
+        case 101:
+            ImageManager.requestFace(params[0]);
+            break;
+
+        // Common Event
+        case 117:
+            var commonEvent = $dataCommonEvents[params[0]];
+            if (commonEvent) {
+                if (!commonList) {
+                    commonList = [];
+                }
+                if (!commonList.contains(params[0])) {
+                    commonList.push(params[0]);
+                    Game_Interpreter.requestImages(commonEvent.list, commonList);
+                }
+            }
+            break;
+
+        // Change Party Member
+        case 129:
+            var actor = $gameActors.actor(params[0]);
+            if (actor && params[1] === 0) {
+                var name = actor.characterName();
+                ImageManager.requestCharacter(name);
+            }
+            break;
+
+        // Set Movement Route
+        case 205:
+            if(params[1]){
+                params[1].list.forEach(function(command){
+                    var params = command.parameters;
+                    if(command.code === Game_Character.ROUTE_CHANGE_IMAGE){
+                        ImageManager.requestCharacter(params[0]);
+                    }
+                });
+            }
+            break;
+
+        // Show Animation, Show Battle Animation
+        case 212: case 337:
+            if(params[1]) {
+                var animation = $dataAnimations[params[1]];
+                var name1 = animation.animation1Name;
+                var name2 = animation.animation2Name;
+                var hue1 = animation.animation1Hue;
+                var hue2 = animation.animation2Hue;
+                ImageManager.requestAnimation(name1, hue1);
+                ImageManager.requestAnimation(name2, hue2);
+            }
+            break;
+
+        // Change Player Followers
+        case 216:
+            if (params[0] === 0) {
+                $gamePlayer.followers().forEach(function(follower) {
+                    var name = follower.characterName();
+                    ImageManager.requestCharacter(name);
+                });
+            }
+            break;
+
+        // Show Picture
+        case 231:
+            ImageManager.requestPicture(params[1]);
+            break;
+
+        // Change Tileset
+        case 282:
+            var tileset = $dataTilesets[params[0]];
+            tileset.tilesetNames.forEach(function(tilesetName){
+                ImageManager.requestTileset(tilesetName);
+            });
+            break;
+
+        // Change Battle Back
+        case 283:
+            if ($gameParty.inBattle()) {
+                ImageManager.requestBattleback1(params[0]);
+                ImageManager.requestBattleback2(params[1]);
+            }
+            break;
+
+        // Change Parallax
+        case 284:
+            if (!$gameParty.inBattle()) {
+                ImageManager.requestParallax(params[0]);
+            }
+            break;
+
+        // Change Actor Images
+        case 322:
+            ImageManager.requestCharacter(params[1]);
+            ImageManager.requestFace(params[3]);
+            ImageManager.requestSvActor(params[5]);
+            break;
+
+        // Change Vehicle Image
+        case 323:
+            var vehicle = $gameMap.vehicle(params[0]);
+            if(vehicle){
+                ImageManager.requestCharacter(params[1]);
+            }
+            break;
+
+        // Enemy Transform
+        case 336:
+            var enemy = $dataEnemies[params[1]];
+            var name = enemy.battlerName;
+            var hue = enemy.battlerHue;
+            if ($gameSystem.isSideView()) {
+                ImageManager.requestSvEnemy(name, hue);
+            } else {
+                ImageManager.requestEnemy(name, hue);
+            }
+            break;
+    }
+};
+
 Game_Interpreter.requestImages = function(list, commonList){
     if(!list) return;
-
-    list.forEach(function(command){
-        var params = command.parameters;
-        switch(command.code){
-            // Show Text
-            case 101:
-                ImageManager.requestFace(params[0]);
-                break;
-
-            // Common Event
-            case 117:
-                var commonEvent = $dataCommonEvents[params[0]];
-                if (commonEvent) {
-                    if (!commonList) {
-                        commonList = [];
-                    }
-                    if (!commonList.contains(params[0])) {
-                        commonList.push(params[0]);
-                        Game_Interpreter.requestImages(commonEvent.list, commonList);
-                    }
-                }
-                break;
-
-            // Change Party Member
-            case 129:
-                var actor = $gameActors.actor(params[0]);
-                if (actor && params[1] === 0) {
-                    var name = actor.characterName();
-                    ImageManager.requestCharacter(name);
-                }
-                break;
-
-            // Set Movement Route
-            case 205:
-                if(params[1]){
-                    params[1].list.forEach(function(command){
-                        var params = command.parameters;
-                        if(command.code === Game_Character.ROUTE_CHANGE_IMAGE){
-                            ImageManager.requestCharacter(params[0]);
-                        }
-                    });
-                }
-                break;
-
-            // Show Animation, Show Battle Animation
-            case 212: case 337:
-                if(params[1]) {
-                    var animation = $dataAnimations[params[1]];
-                    var name1 = animation.animation1Name;
-                    var name2 = animation.animation2Name;
-                    var hue1 = animation.animation1Hue;
-                    var hue2 = animation.animation2Hue;
-                    ImageManager.requestAnimation(name1, hue1);
-                    ImageManager.requestAnimation(name2, hue2);
-                }
-                break;
-
-            // Change Player Followers
-            case 216:
-                if (params[0] === 0) {
-                    $gamePlayer.followers().forEach(function(follower) {
-                        var name = follower.characterName();
-                        ImageManager.requestCharacter(name);
-                    });
-                }
-                break;
-
-            // Show Picture
-            case 231:
-                ImageManager.requestPicture(params[1]);
-                break;
-
-            // Change Tileset
-            case 282:
-                var tileset = $dataTilesets[params[0]];
-                tileset.tilesetNames.forEach(function(tilesetName){
-                    ImageManager.requestTileset(tilesetName);
-                });
-                break;
-
-            // Change Battle Back
-            case 283:
-                if ($gameParty.inBattle()) {
-                    ImageManager.requestBattleback1(params[0]);
-                    ImageManager.requestBattleback2(params[1]);
-                }
-                break;
-
-            // Change Parallax
-            case 284:
-                if (!$gameParty.inBattle()) {
-                    ImageManager.requestParallax(params[0]);
-                }
-                break;
-
-            // Change Actor Images
-            case 322:
-                ImageManager.requestCharacter(params[1]);
-                ImageManager.requestFace(params[3]);
-                ImageManager.requestSvActor(params[5]);
-                break;
-
-            // Change Vehicle Image
-            case 323:
-                var vehicle = $gameMap.vehicle(params[0]);
-                if(vehicle){
-                    ImageManager.requestCharacter(params[1]);
-                }
-                break;
-
-            // Enemy Transform
-            case 336:
-                var enemy = $dataEnemies[params[1]];
-                var name = enemy.battlerName;
-                var hue = enemy.battlerHue;
-                if ($gameSystem.isSideView()) {
-                    ImageManager.requestSvEnemy(name, hue);
-                } else {
-                    ImageManager.requestEnemy(name, hue);
-                }
-                break;
-        }
-    });
+    list.forEach(Game_Interpreter.requestImageForCommand);
 };

--- a/js/rpg_windows/Window_Options.js
+++ b/js/rpg_windows/Window_Options.js
@@ -48,7 +48,7 @@ Window_Options.prototype.addVolumeOptions = function() {
 Window_Options.prototype.drawItem = function(index) {
     var rect = this.itemRectForText(index);
     var statusWidth = this.statusWidth();
-    var titleWidth = rect,x+rect.width - statusWidth;
+    var titleWidth = rect.x+rect.width - statusWidth;
     this.resetTextColor();
     this.changePaintOpacity(this.isCommandEnabled(index));
     this.drawText(this.commandName(index), rect.x, rect.y, titleWidth, 'left');

--- a/js/rpg_windows/Window_Options.js
+++ b/js/rpg_windows/Window_Options.js
@@ -48,7 +48,7 @@ Window_Options.prototype.addVolumeOptions = function() {
 Window_Options.prototype.drawItem = function(index) {
     var rect = this.itemRectForText(index);
     var statusWidth = this.statusWidth();
-    var titleWidth = rect.width - statusWidth;
+    var titleWidth = rect,x+rect.width - statusWidth;
     this.resetTextColor();
     this.changePaintOpacity(this.isCommandEnabled(index));
     this.drawText(this.commandName(index), rect.x, rect.y, titleWidth, 'left');

--- a/js/rpg_windows/Window_Options.js
+++ b/js/rpg_windows/Window_Options.js
@@ -48,11 +48,11 @@ Window_Options.prototype.addVolumeOptions = function() {
 Window_Options.prototype.drawItem = function(index) {
     var rect = this.itemRectForText(index);
     var statusWidth = this.statusWidth();
-    var titleWidth = rect.x+rect.width - statusWidth;
+    var titleWidth = rect.width - statusWidth;
     this.resetTextColor();
     this.changePaintOpacity(this.isCommandEnabled(index));
     this.drawText(this.commandName(index), rect.x, rect.y, titleWidth, 'left');
-    this.drawText(this.statusText(index), titleWidth, rect.y, statusWidth, 'right');
+    this.drawText(this.statusText(index), rect.x+titleWidth, rect.y, statusWidth, 'right');
 };
 
 Window_Options.prototype.statusWidth = function() {


### PR DESCRIPTION
When remodeling with plug-in, trying to make two rows requires modification of the main body.
The specification to reflect the X of the itemRect () coordinates to draw the volume figure.
Until now, X was 0, so it did not matter.

プラグインで改造するときに、2列にしようとすると本体改造が必要となる。
音量の数字を描画する座標がitemRect()のXを反映する仕様に。
今までだとXは多くの場合0だったので問題にならなかった。