### PR TITLE
fix cannot save on Enigma Virtual Box

### DIFF
--- a/js/rpg_managers/StorageManager.js
+++ b/js/rpg_managers/StorageManager.js
@@ -195,7 +195,11 @@ StorageManager.localFileDirectoryPath = function() {
     var path = require('path');
 
     var base = path.dirname(process.mainModule.filename);
-    return path.join(base, 'save/');
+    if (this.canMakeWwwSaveDirectory()) {
+        return path.join(base, 'save/');
+    } else {
+        return path.join(path.dirname(base), 'save/');
+    }
 };
 
 StorageManager.localFilePath = function(savefileId) {
@@ -218,4 +222,22 @@ StorageManager.webStorageKey = function(savefileId) {
     } else {
         return 'RPG File%1'.format(savefileId);
     }
+};
+
+// Enigma Virtual Box cannot make www/save directory
+StorageManager.canMakeWwwSaveDirectory = function() {
+    if (this._canMakeWwwSaveDirectory === undefined) {
+        var fs = require('fs');
+        var path = require('path');
+        var base = path.dirname(process.mainModule.filename);
+        var testPath = path.join(base, 'testDirectory/');
+        try {
+            fs.mkdirSync(testPath);
+            fs.rmdirSync(testPath);
+            this._canMakeWwwSaveDirectory = true;
+        } catch (e) {
+            this._canMakeWwwSaveDirectory = false;
+        }
+    }
+    return this._canMakeWwwSaveDirectory;
 };


### PR DESCRIPTION
If you consolidate your RMMV game using by Enigma Virtual Box, players cannot save the games.
It is because "consolidated" game cannot make `www/save` directory.
Fixed!