### PR TITLE
play video with audio throw error at Mac Safari

### DIFF
--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -1044,7 +1044,7 @@ Graphics._applyCanvasFilter = function() {
  * @private
  */
 Graphics._onVideoLoad = function() {
-    this._video.play();
+    this._video.play().catch(function() { });
     this._updateVisibility(true);
     this._videoLoading = false;
 };


### PR DESCRIPTION
Safari 11 has Auto-Play blocking.
http://takasfz.hatenablog.com/entry/2017/06/19/173227

So, play mp4 with audio track throw NotAllowedError.
![image](https://user-images.githubusercontent.com/856424/34940452-f3094afc-fa32-11e7-9753-05630b08fe06.png)

https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play

Needs user-jesture to play mp4 with audio.

This PR is just fix error. it's not good way. (and what is good way?)
