### PR TITLE
Don't stop the game on browser extension's error

### DIFF
--- a/js/rpg_managers/SceneManager.js
+++ b/js/rpg_managers/SceneManager.js
@@ -151,12 +151,14 @@ SceneManager.terminate = function() {
 
 SceneManager.onError = function(e) {
     console.error(e.message);
-    console.error(e.filename, e.lineno);
-    try {
-        this.stop();
-        Graphics.printError('Error', e.message);
-        AudioManager.stopAll();
-    } catch (e2) {
+    if (e.filename || e.lineno) {
+        console.error(e.filename, e.lineno);
+        try {
+            this.stop();
+            Graphics.printError('Error', e.message);
+            AudioManager.stopAll();
+        } catch (e2) {
+        }
     }
 };
 


### PR DESCRIPTION
`SceneManager.onError` catches all errors including browser extension's errors.
But, game creators have no responsibility for browser extension's errors, and players want to continue the game without error.
So, showing these errors should be suppressed.