### PR TITLE
Add text speed

### DIFF
--- a/js/rpg_windows/Window_Message.js
+++ b/js/rpg_windows/Window_Message.js
@@ -57,6 +57,8 @@ Window_Message.prototype.clearFlags = function() {
     this._showFast = false;
     this._lineShowFast = false;
     this._pauseSkip = false;
+    this._textSpeed = 0;
+    this._textSpeedCount = 0;
 };
 
 Window_Message.prototype.numVisibleRows = function() {
@@ -176,8 +178,13 @@ Window_Message.prototype.updateMessage = function() {
                 this.newPage(this._textState);
             }
             this.updateShowFast();
+            if (!this._showFast && !this._lineShowFast && this._textSpeedCount < this._textSpeed) {
+                this._textSpeedCount++;
+                break;
+            }
+            this._textSpeedCount = 0;
             this.processCharacter(this._textState);
-            if (!this._showFast && !this._lineShowFast) {
+            if (!this._showFast && !this._lineShowFast && this._textSpeed !== -1) {
                 break;
             }
             if (this.pause || this._waitCount > 0) {
@@ -312,6 +319,9 @@ Window_Message.prototype.processEscapeCharacter = function(code, textState) {
         break;
     case '^':
         this._pauseSkip = true;
+        break;
+    case 'S':
+        this._textSpeed = this.obtainEscapeParam(textState) - 1;
         break;
     default:
         Window_Base.prototype.processEscapeCharacter.call(this, code, textState);

--- a/plugins/Community_Basic.js
+++ b/plugins/Community_Basic.js
@@ -42,6 +42,11 @@
  * @desc The initial value whether the player always dashes (on/off)
  * @default false
  *
+ * @param textSpeed
+ * @type number
+ * @desc The text speed on "Show Text". The larger this parameter is, the slower text speed. (0: show all texts at once)
+ * @default 1
+ *
  * @param autoSaveFileId
  * @type number
  * @desc The file number to auto save when "Transfer Player" (0: off)
@@ -97,6 +102,12 @@
  * @desc プレイヤーが常時ダッシュするかどうかの初期値 (on/off)
  * @default false
  *
+ * @param textSpeed
+ * @type number
+ * @text 「文章の表示」のスピード
+ * @desc 数字が大きいほど文章の表示スピードが遅くなります (0を指定した場合は一度に全文を表示します)
+ * @default 1
+ *
  * @param autoSaveFileId
  * @type number
  * @desc 「場所移動」の際にオートセーブするファイル番号 (0でoff)
@@ -124,6 +135,7 @@
     var screenHeight = toNumber(parameters['screenHeight'], 624);
     var renderingMode = parameters['renderingMode'].toLowerCase();
     var alwaysDash = parameters['alwaysDash'].toLowerCase() === 'true';
+    var textSpeed = toNumber(parameters['textSpeed'], 1);
     var windowWidthTo = toNumber(parameters['changeWindowWidthTo'], 0);
     var windowHeightTo = toNumber(parameters['changeWindowHeightTo'], 0);
     var autoSaveFileId = toNumber(parameters['autoSaveFileId'], 0);
@@ -173,6 +185,11 @@
         }
     };
 
+    var _Window_Message_clearFlags = Window_Message.prototype.clearFlags;
+    Window_Message.prototype.clearFlags = function(textState) {
+        _Window_Message_clearFlags.apply(this, arguments);
+        this._textSpeed = textSpeed - 1;
+    };
 
     var _SceneManager_initNwjs = SceneManager.initNwjs;
     SceneManager.initNwjs = function() {


### PR DESCRIPTION
Add text speed!

Usage:

1. To set the text speed, write `\S[number]` In "Show text" messages. The larger the number is, the slower the text speed. The default speed is `\S[1]`. If `\S[0]` set, show all texts at once!
1. Set the default text speed for the whole game by the plugin parameter of Community_Basic.js `textSpeed`. The meaning of number is the same as `\S[number]`.