### PR TITLE
setCursorAllFix

### DIFF
--- a/js/rpg_scenes/Scene_ItemBase.js
+++ b/js/rpg_scenes/Scene_ItemBase.js
@@ -88,9 +88,12 @@ Scene_ItemBase.prototype.activateItemWindow = function() {
     this._itemWindow.activate();
 };
 
-Scene_ItemBase.prototype.itemTargetActors = function() {
-    var action = new Game_Action(this.user());
-    action.setItemObject(this.item());
+Scene_ItemBase.prototype.action=function(){
+    return this._actorWindow.action();
+};
+
+Scene_ItemBase.prototype.itemTargetActors =function(){
+    var action = this.action();
     if (!action.isForFriend()) {
         return [];
     } else if (action.isForAll()) {
@@ -105,21 +108,21 @@ Scene_ItemBase.prototype.canUse = function() {
 };
 
 Scene_ItemBase.prototype.isItemEffectsValid = function() {
-    var action = new Game_Action(this.user());
-    action.setItemObject(this.item());
+    var action = this.action();
     return this.itemTargetActors().some(function(target) {
         return action.testApply(target);
     }, this);
 };
 
-Scene_ItemBase.prototype.applyItem = function() {
-    var action = new Game_Action(this.user());
-    action.setItemObject(this.item());
-    this.itemTargetActors().forEach(function(target) {
-        for (var i = 0; i < action.numRepeats(); i++) {
-            action.apply(target);
+Scene_ItemBase.prototype.applyItem =function(){
+    var action = this.action();
+    var targets = this.itemTargetActors();
+    targets.forEach(function(battler) {
+        var repeats = action.numRepeats();
+        for (var i = 0; i < repeats; i++) {
+            action.apply(battler);                    
         }
-    }, this);
+    });
     action.applyGlobal();
 };
 

--- a/js/rpg_windows/Window_MenuActor.js
+++ b/js/rpg_windows/Window_MenuActor.js
@@ -13,6 +13,11 @@ Window_MenuActor.prototype.constructor = Window_MenuActor;
 Window_MenuActor.prototype.initialize = function() {
     Window_MenuStatus.prototype.initialize.call(this, 0, 0);
     this.hide();
+    this._action =null;
+};
+
+Window_MenuActor.prototype.action =function(){
+    return this._action;
 };
 
 Window_MenuActor.prototype.processOk = function() {
@@ -26,23 +31,35 @@ Window_MenuActor.prototype.selectLast = function() {
     this.select($gameParty.targetActor().index() || 0);
 };
 
-Window_MenuActor.prototype.selectForItem = function(item) {
+Window_MenuActor.prototype.selectDefaultTarget =function(){
+    if(!this._cursorAll){
+        if(this._action.isForUser()){
+            this.select(this._action.subject().index());
+        }else{
+            this.selectLast();
+        }    
+    }
+};
+
+Window_MenuActor.prototype.needsSelection =function(){
+    var action = this._action;
+    if(this._action.isForUser() && this._action.isItem() ){
+        return true;
+    }
+    return this._action.needsSelection();
+};
+
+Window_MenuActor.prototype.isActionForAll=function(){
+    return !this._action.isForOne();
+};
+
+Window_MenuActor.prototype.selectForItem =function(item){
     var actor = $gameParty.menuActor();
     var action = new Game_Action(actor);
     action.setItemObject(item);
-    this.setCursorFixed(false);
-    this.setCursorAll(false);
-    if (action.isForUser()) {
-        if (DataManager.isSkill(item)) {
-            this.setCursorFixed(true);
-            this.select(actor.index());
-        } else {
-            this.selectLast();
-        }
-    } else if (action.isForAll()) {
-        this.setCursorAll(true);
-        this.select(0);
-    } else {
-        this.selectLast();
-    }
+    this._action = action;
+
+    this.setCursorFixed(!this.needsSelection());
+    this.setCursorAll(this.isActionForAll());
+    this.selectDefaultTarget();
 };

--- a/js/rpg_windows/Window_Selectable.js
+++ b/js/rpg_windows/Window_Selectable.js
@@ -41,7 +41,11 @@ Window_Selectable.prototype.cursorAll = function() {
 };
 
 Window_Selectable.prototype.setCursorAll = function(cursorAll) {
-    this._cursorAll = cursorAll;
+    var lastValue = this._cursorAll;
+    this._cursorAll = !!cursorAll;
+    if(lastValue !==this._cursorAll){
+        this.updateCursor();
+    }
 };
 
 Window_Selectable.prototype.maxCols = function() {


### PR DESCRIPTION
Even if you call setCursorAll (), the cursor does not change immediately.
It was inconvenient to call this function from the plugin, so I would like to fix it.
With Window_MenuActor.selectForItem (), updateCursor () is called twice, which is wasteful of processing.
This is fixed with another commit.