### PR TITLE
Input.AddSymbol

### DIFF
--- a/js/rpg_core/Input.js
+++ b/js/rpg_core/Input.js
@@ -73,6 +73,33 @@ Input.keyMapper = {
 };
 
 /**
+ * @param {Number} keyNumber
+ * @param {String} symbol
+ */
+Input.addSymbolToKey = function(keyNumber,symbol){
+    this.keyMapper[keyNumber] = symbol;
+};
+
+/**
+ * @param {String} keys
+ * @param {String} symbol
+ */
+Input.addSymbolsToMultipleKeys = function(keys,symbol){
+    var keysCount = keys.length;
+    for(var i=0; i< keysCount;++i){
+        this.addSymbolToKey(keys.charCodeAt(i),symbol);
+    }
+};
+
+/**
+ * @param {Number} keys
+ * @param {String} symbol
+ */
+Input.addSymbolsToPadButton =function(buttonId,symbol){
+    this.gamepadMapper[buttonId]=symbol;
+};
+
+/**
  * A hash table to convert from a gamepad button to a mapped key name.
  *
  * @static


### PR DESCRIPTION
Ability to add symbols for keyboard and game pad.
Although it is possible to add data directly to the table, it is possible to create room for other plugins to hook by inserting a function.
addSymbolsToMultipleKeys () is a function to register symbols in multiple keys by using the fact that the character code and key code match.
Although it is limited to capital letters, it was suggested that it was easy to use by incorporating it into a plug-in.