### PR TITLE
canUse BugFix

### DIFF
--- a/js/rpg_scenes/Scene_ItemBase.js
+++ b/js/rpg_scenes/Scene_ItemBase.js
@@ -101,7 +101,11 @@ Scene_ItemBase.prototype.itemTargetActors = function() {
 };
 
 Scene_ItemBase.prototype.canUse = function() {
-    return this.user().canUse(this.item()) && this.isItemEffectsValid();
+    var user = this.user();
+    if(user){
+        return user.canUse(this.item()) && this.isItemEffectsValid();
+    }
+    return false;
 };
 
 Scene_ItemBase.prototype.isItemEffectsValid = function() {


### PR DESCRIPTION
There are rare cases where characters that can use items do not exist.
When I try to use an item at such a time, it falls with null reference.