### PR TITLE
DrawCharacter BugFix

### DIFF
--- a/js/rpg_windows/Window_Base.js
+++ b/js/rpg_windows/Window_Base.js
@@ -452,7 +452,7 @@ Window_Base.prototype.drawCharacter = function(characterName, characterIndex, x,
     var big = ImageManager.isBigCharacter(characterName);
     var pw = bitmap.width / (big ? 3 : 12);
     var ph = bitmap.height / (big ? 4 : 8);
-    var n = characterIndex;
+    var n = big ? 0: characterIndex;
     var sx = (n % 4 * 3 + 1) * pw;
     var sy = (Math.floor(n / 4) * 4) * ph;
     this.contents.blt(bitmap, sx, sy, pw, ph, x - pw / 2, y - ph);


### PR DESCRIPTION
Fixed a bug in Window_Base.drawCharacter ().
There was a case that it was not displayed when it made it into a single walking graphic with an editor.