### PR TITLE
Fix can't read the Ogg loop tag when metadata has over 255 bytes

### DIFF
--- a/js/rpg_core/WebAudio.js
+++ b/js/rpg_core/WebAudio.js
@@ -761,7 +761,14 @@ WebAudio.prototype._readOgg = function(array) {
                     if (headerType === 1) {
                         this._sampleRate = this._readLittleEndian(array, index + 12);
                     } else if (headerType === 3) {
-                        this._readMetaData(array, index, segments[i]);
+                        var size = 0;
+                        for (; i < numSegments; i++) {
+                            size += segments[i];
+                            if (segments[i] < 255) {
+                                break;
+                            }
+                        }
+                        this._readMetaData(array, index, size);
                     }
                     vorbisHeaderFound = true;
                 }


### PR DESCRIPTION
`WebAudio` can't read the Ogg loop tag under the following conditions.

- metadata has over 255 bytes (= spans multiple segments)
- LOOPSTART or LOOPLENGTH appears after byte 256 (= appears after the 2nd segment)

So I fixed it to read as metadata up to the size of the following segment when the segment size of the metadata is 255 bytes.
This behavior is in accordance with the specification of OGG format.


[Ogg - Wikipedia](https://en.wikipedia.org/wiki/Ogg)
Page structure
> When the segment's length is indicated to be 255, this indicates that the following segment is to be concatenated to this one and is part of the same packet.

[Ogg Documentation](https://www.xiph.org/ogg/doc/framing.html)
Packet segmentation
> Note that a lacing value of 255 implies that a second lacing value follows in the packet, and a value of < 255 marks the end of the packet after that many additional bytes. 