### PR TITLE
redesign & bugfix progress bar

### DIFF
--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -251,21 +251,26 @@ Graphics.startLoading = function() {
 
     ProgressWatcher.truncateProgress();
     ProgressWatcher.setProgressListener(this._updateProgressCount.bind(this));
-    Graphics._showProgress();
+    this._progressTimeout = setTimeout(function() {
+        Graphics._showProgress();
+    }, 1500);
 };
 
 Graphics._setupProgress = function(){
     this._progressElement = document.createElement('div');
     this._progressElement.id = 'loading-progress';
-    this._progressElement.style.width = '200px';
-    this._progressElement.style.height = '30px';
-    this._progressElement.style.backgroundColor = 'gray';
+    this._progressElement.width = 600;
+    this._progressElement.height = 30;
+    this._progressElement.style.background = 'linear-gradient(to top, gray, lightgray)';
+    this._progressElement.style.border = '5px solid white';
+    this._progressElement.style.borderRadius = '15px';
 
     this._barElement = document.createElement('div');
     this._barElement.id = 'loading-bar';
-    this._barElement.style.width = '1%';
-    this._barElement.style.height = '30px';
-    this._barElement.style.backgroundColor = 'green';
+    this._barElement.style.width = '0%';
+    this._barElement.style.height = '100%';
+    this._barElement.style.background = 'linear-gradient(to top, lime, palegreen)';
+    this._barElement.style.borderRadius = '10px';
 
     this._progressElement.appendChild(this._barElement);
 
@@ -295,7 +300,7 @@ Graphics._updateProgressCount = function(countLoaded, countLoading){
 Graphics._updateProgress = function(){
     this._progressElement.style.zIndex = 99;
     this._centerElement(this._progressElement);
-    this._progressElement.style.marginTop = '400px';
+    this._progressElement.style.marginTop = 450 * this._realScale + 'px';
 };
 
 /**
@@ -321,6 +326,7 @@ Graphics.endLoading = function() {
     this._clearUpperCanvas();
     this._upperCanvas.style.opacity = 0;
     this._hideProgress();
+    clearTimeout(this._progressTimeout);
 };
 
 /**


### PR DESCRIPTION
1. Redesign progress bar
1. bar's width & height get to be influenced by `Graphics._realScale`
1. displaying bar only when it takes over 1.5sec to load

progress bar design
before
![before](https://user-images.githubusercontent.com/20380362/41502618-17c74838-71f9-11e8-8636-688a5898901c.png)

after
![gradient](https://user-images.githubusercontent.com/20380362/41502619-17f15fec-71f9-11e8-9e70-91501395ea78.png)