### PR TITLE
Playtime ticked by game frames, not rendering frames

### DIFF
--- a/js/rpg_objects/Game_System.js
+++ b/js/rpg_objects/Game_System.js
@@ -16,6 +16,7 @@ Game_System.prototype.initialize = function() {
     this._winCount = 0;
     this._escapeCount = 0;
     this._saveCount = 0;
+    this._frameCount = 0;
     this._versionId = 0;
     this._framesOnSave = 0;
     this._bgmOnSave = null;
@@ -116,6 +117,10 @@ Game_System.prototype.saveCount = function() {
     return this._saveCount;
 };
 
+Game_System.prototype.frameCount = function() {
+    return this._frameCount;
+};
+
 Game_System.prototype.versionId = function() {
     return this._versionId;
 };
@@ -164,6 +169,10 @@ Game_System.prototype.onBattleEscape = function() {
     this._escapeCount++;
 };
 
+Game_System.prototype.onFrameUpdate = function() {
+    this._frameCount++;
+};
+
 Game_System.prototype.onBeforeSave = function() {
     this._saveCount++;
     this._versionId = $dataSystem.versionId;
@@ -179,7 +188,7 @@ Game_System.prototype.onAfterLoad = function() {
 };
 
 Game_System.prototype.playtime = function() {
-    return Math.floor(Graphics.frameCount / 60);
+    return Math.floor(this._frameCount / 60);
 };
 
 Game_System.prototype.playtimeText = function() {

--- a/js/rpg_objects/Game_System.js
+++ b/js/rpg_objects/Game_System.js
@@ -182,6 +182,9 @@ Game_System.prototype.onBeforeSave = function() {
 };
 
 Game_System.prototype.onAfterLoad = function() {
+    if (!this._frameCount) {
+        this._frameCount = this._framesOnSave;
+    }
     Graphics.frameCount = this._framesOnSave;
     AudioManager.playBgm(this._bgmOnSave);
     AudioManager.playBgs(this._bgsOnSave);

--- a/js/rpg_scenes/Scene_Base.js
+++ b/js/rpg_scenes/Scene_Base.js
@@ -105,6 +105,7 @@ Scene_Base.prototype.start = function() {
  * @memberof Scene_Base
  */
 Scene_Base.prototype.update = function() {
+    $gameSystem.onFrameUpdate();
     this.updateFade();
     this.updateChildren();
 };


### PR DESCRIPTION
Until now, the play time was counted as the number of times the game was rendered. In other words, the higher the refresh rate of the monitor, the more the play time is added. That is ridiculous! Therefore, we decided to count play time by the number of game frames.