### PR TITLE
fix corrupted part of descender and outline when using Bitmap#drawSmallText

### DIFF
--- a/js/rpg_core/Bitmap.js
+++ b/js/rpg_core/Bitmap.js
@@ -678,12 +678,21 @@ Bitmap.prototype.drawSmallText = function(text, x, y, maxWidth, lineHeight, alig
     bitmap.outlineColor = this.outlineColor;
     bitmap.outlineWidth = this.outlineWidth * minFontSize / this.fontSize;
     maxWidth = maxWidth || 816;
+    var height = this.fontSize * 1.5;
     var scaledMaxWidth = maxWidth * minFontSize / this.fontSize;
-    if (scaledMaxWidth > bitmap.width) {
-        bitmap.width *= 2;
-    }
-    bitmap.drawText(text, 0, 0, scaledMaxWidth, minFontSize, align);
-    this.blt(bitmap, 0, 0, scaledMaxWidth, minFontSize, x, y + (lineHeight - this.fontSize) / 2, maxWidth, this.fontSize);
+    var scaledMaxWidthWithOutline = scaledMaxWidth + bitmap.outlineWidth * 2;
+    var scaledHeight = height * minFontSize / this.fontSize;
+    var scaledHeightWithOutline = scaledHeight + bitmap.outlineWidth * 2;
+
+    var bitmapWidth = bitmap.width;
+    var bitmapHeight = bitmap.height;
+    while (scaledMaxWidthWithOutline > bitmapWidth) bitmapWidth *= 2;
+    while (scaledHeightWithOutline > bitmapHeight) bitmapHeight *= 2;
+    if (bitmap.width !== bitmapWidth || bitmap.height !== bitmapHeight) bitmap.resize(bitmapWidth, bitmapHeight);
+
+    bitmap.drawText(text, bitmap.outlineWidth, bitmap.outlineWidth, scaledMaxWidth, minFontSize, align);
+    this.blt(bitmap, 0, 0, scaledMaxWidthWithOutline, scaledHeightWithOutline,
+        x - this.outlineWidth, y - this.outlineWidth + (lineHeight - this.fontSize) / 2, maxWidth + this.outlineWidth * 2, height + this.outlineWidth * 2);
     bitmap.clear();
 };
 


### PR DESCRIPTION
`Bitmap#drawSmallText` has 2 problems :sob:

-----

(1)
`bitmap.width` is read only property.
so, `bitmap.width *= 2` is not working.
https://github.com/rpgtkoolmv/corescript/blob/cbc82b3e96112cf8122f29c30713f63ec6df2251/js/rpg_core/Bitmap.js#L328-L343

(2) 
`Bitmap#drawSmallText` cannot drawn `outline` (Bitmap#outlineWidth) or descender alphabet (ex. `g`, `j`, `p` ...)... :scream:

------

I try fix these issues.
Please check this PR :pray:

![preview](https://user-images.githubusercontent.com/1131422/43989231-d0caef3a-9d80-11e8-972f-f21ee01cd229.gif)
