### PR TITLE
fix baseline position on Safari according to Chrome and Firefox

### DIFF
--- a/js/rpg_core/Bitmap.js
+++ b/js/rpg_core/Bitmap.js
@@ -634,7 +634,7 @@ Bitmap.prototype.drawText = function(text, x, y, maxWidth, lineHeight, align) {
             return;
         }
         var tx = x;
-        var ty = y + lineHeight - (lineHeight - this.fontSize * 0.7) / 2;
+        var ty = y + lineHeight - Math.round((lineHeight - this.fontSize * 0.7) / 2);
         var context = this._context;
         var alpha = context.globalAlpha;
         maxWidth = maxWidth || 0xffffffff;


### PR DESCRIPTION
I noticed, some text positions are shifted by 1 px on Safari. :expressionless:

![preview02](https://user-images.githubusercontent.com/1131422/43989579-7d027736-9d87-11e8-8750-1fee25ee0c59.gif)

( I checked on Safari, Chrome and Firefox for macOS. )
