### PR TITLE
Fix touches were not refreshed when the game window lost focus

### DIFF
--- a/js/rpg_core/TouchInput.js
+++ b/js/rpg_core/TouchInput.js
@@ -256,6 +256,7 @@ TouchInput._setupEventHandlers = function() {
     document.addEventListener('touchend', this._onTouchEnd.bind(this));
     document.addEventListener('touchcancel', this._onTouchCancel.bind(this));
     document.addEventListener('pointerdown', this._onPointerDown.bind(this));
+    window.addEventListener('blur', this._onLostFocus.bind(this));
 };
 
 /**
@@ -438,6 +439,15 @@ TouchInput._onPointerDown = function(event) {
             event.preventDefault();
         }
     }
+};
+
+/**
+ * @static
+ * @method _onLostFocus
+ * @private
+ */
+TouchInput._onLostFocus = function() {
+    this.clear();
 };
 
 /**


### PR DESCRIPTION
`Input` is refreshed when the game window lost focus, but `TouchInput` is not.
So, if you change the window with keeping mousedown, mouseup never fired despite you mouseup!
It is ridiculous, so fixed it.