### PR TITLE
Fix map events are invoked twice on the same frame when you touch them a long time

### DIFF
--- a/js/rpg_scenes/Scene_Map.js
+++ b/js/rpg_scenes/Scene_Map.js
@@ -68,6 +68,9 @@ Scene_Map.prototype.update = function() {
 Scene_Map.prototype.updateMainMultiply = function() {
     this.updateMain();
     if (this.isFastForward()) {
+        if (!this.isMapTouchOk()) {
+            this.updateDestination();
+        }
         this.updateMain();
     }
 };


### PR DESCRIPTION
When `Scene_Map.prototype.isFastForward` is `true` and you long touch a event, it is duplicate executed.
Fixed it!