### PR TITLE
Delete Utils.canReadGameFiles method

### DIFF
--- a/js/rpg_core/Utils.js
+++ b/js/rpg_core/Utils.js
@@ -100,27 +100,6 @@ Utils.isAndroidChrome = function() {
 };
 
 /**
- * Checks whether the browser can read files in the game folder.
- *
- * @static
- * @method canReadGameFiles
- * @return {Boolean} True if the browser can read files in the game folder
- */
-Utils.canReadGameFiles = function() {
-    var scripts = document.getElementsByTagName('script');
-    var lastScript = scripts[scripts.length - 1];
-    var xhr = new XMLHttpRequest();
-    try {
-        xhr.open('GET', lastScript.src);
-        xhr.overrideMimeType('text/javascript');
-        xhr.send();
-        return true;
-    } catch (e) {
-        return false;
-    }
-};
-
-/**
  * Makes a CSS color string from RGB values.
  *
  * @static

--- a/js/rpg_managers/SceneManager.js
+++ b/js/rpg_managers/SceneManager.js
@@ -45,7 +45,6 @@ SceneManager.run = function(sceneClass) {
 SceneManager.initialize = function() {
     this.initProgressWatcher();
     this.initGraphics();
-    this.checkFileAccess();
     this.initAudio();
     this.initInput();
     this.initNwjs();
@@ -88,12 +87,6 @@ SceneManager.shouldUseCanvasRenderer = function() {
 SceneManager.checkWebGL = function() {
     if (!Graphics.hasWebGL()) {
         throw new Error('Your browser does not support WebGL.');
-    }
-};
-
-SceneManager.checkFileAccess = function() {
-    if (!Utils.canReadGameFiles()) {
-        throw new Error('Your browser does not allow to read local files.');
     }
 };
 


### PR DESCRIPTION
What this method does is:
1. take all already loaded scripts
2. try to load the last one again. If success, ok, if not, error.

However, if the target script cannot be loaded, rpg_core.js cannot be loaded either. And when rpg_core.js is not loaded, Utils.canReadGameFiles cannot be executed.
Therefore this function is completely redundant, since if loading worked perfectly, we will see it, and if not, this function cannot even execute to check for it.
I also removed the code from SceneManager to make sure the game won't crash from removing the utils method.