### PR TITLE
Fix cannot draw window's contents or backgrounds correctly

### DIFF
--- a/js/rpg_core/Bitmap.js
+++ b/js/rpg_core/Bitmap.js
@@ -989,6 +989,10 @@ Bitmap.prototype._setDirty = function() {
 Bitmap.prototype.checkDirty = function() {
     if (this._dirty) {
         this._baseTexture.update();
+        var baseTexture = this._baseTexture;
+        setTimeout(function() {
+            baseTexture.update();
+        }, 0);
         this._dirty = false;
     }
 };


### PR DESCRIPTION
In Chrome 69, the contents and background of the windows are often not rendered correctly when the scene is changed quickly.

The investigation found that this is a bug in PIXI or Chrome 69.
I reported this to the PIXI community (
https://github.com/pixijs/pixi.js/issues/5136), but they do not seem to deal with this problem.
So I wrote a hotfix.

It is unclear why this hotfix solves the problem. 😨 