### PR TITLE
Fix rendering stopped when changed user agent mobile safari to another.

### DIFF
--- a/js/rpg_managers/SceneManager.js
+++ b/js/rpg_managers/SceneManager.js
@@ -228,6 +228,7 @@ SceneManager.updateMain = function() {
         this.updateScene();
     } else {
         var newTime = this._getTimeInMsWithoutMobileSafari();
+        if (this._currentTime === undefined) this._currentTime = newTime;
         var fTime = (newTime - this._currentTime) / 1000;
         if (fTime > 0.25) fTime = 0.25;
         this._currentTime = newTime;

--- a/js/rpg_managers/SceneManager.js
+++ b/js/rpg_managers/SceneManager.js
@@ -228,9 +228,9 @@ SceneManager.updateMain = function() {
         this.updateScene();
     } else {
         var newTime = this._getTimeInMsWithoutMobileSafari();
-        if (this._currentTime === undefined) this._currentTime = newTime;
+        if (this._currentTime === undefined) { this._currentTime = newTime; }
         var fTime = (newTime - this._currentTime) / 1000;
-        if (fTime > 0.25) fTime = 0.25;
+        if (fTime > 0.25) { fTime = 0.25; }
         this._currentTime = newTime;
         this._accumulator += fTime;
         while (this._accumulator >= this._deltaTime) {


### PR DESCRIPTION
If you first start the game with the mobile safari user agent and later change it to another user agent, the rendering stops and the game hangs up.

The cause is that `this._accumulator` would be `NaN` because `this._currentTime` is `undefined`.

Fixed!