### PR TITLE
Fix the game screen freezes occasionally even though you hear the sounds

### DIFF
--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -161,7 +161,7 @@ Graphics.tickEnd = function() {
  * @param {Stage} stage The stage object to be rendered
  */
 Graphics.render = function(stage) {
-    if (this._skipCount === 0) {
+    if (this._skipCount <= 0) {
         var startTime = Date.now();
         if (stage) {
             this._renderer.render(stage);


### PR DESCRIPTION
The problem of "the screen freezes extremely occasionally despite the sound being heard" was previously reported.

It turned out that the reason for this is that `this._skipCount` is a negative number.
This is how it works.

1. `startTime` is determined based on `Date.now() `.
1. During rendering, the OS corrects the clock and the time rewinds.
1. `endTime` is determined based on `Date.now() `.
1. `startTime > endTime` so `elapsed` is negative.
1. `elapsed` is negative so `this._skipCount` is negative.
1. `this._skipCount` is negative so the game is no longer rendered.

Fixed!