### PR TITLE
Fix delay of drawing maps after NewGame

### DIFF
--- a/js/rpg_sprites/Spriteset_Base.js
+++ b/js/rpg_sprites/Spriteset_Base.js
@@ -60,6 +60,7 @@ Spriteset_Base.prototype.createWebGLToneChanger = function() {
     var width = Graphics.width + margin * 2;
     var height = Graphics.height + margin * 2;
     this._toneFilter = new ToneFilter();
+    this._toneFilter.enabled = false;
     this._baseSprite.filters = [this._toneFilter];
     this._baseSprite.filterArea = new Rectangle(-margin, -margin, width, height);
 };
@@ -116,8 +117,13 @@ Spriteset_Base.prototype.updateToneChanger = function() {
 Spriteset_Base.prototype.updateWebGLToneChanger = function() {
     var tone = this._tone;
     this._toneFilter.reset();
-    this._toneFilter.adjustTone(tone[0], tone[1], tone[2]);
-    this._toneFilter.adjustSaturation(-tone[3]);
+    if (tone[0] || tone[1] || tone[2] || tone[3]) {
+        this._toneFilter.enabled = true;
+        this._toneFilter.adjustTone(tone[0], tone[1], tone[2]);
+        this._toneFilter.adjustSaturation(-tone[3]);
+    } else {
+        this._toneFilter.enabled = false;
+    }
 };
 
 Spriteset_Base.prototype.updateCanvasToneChanger = function() {


### PR DESCRIPTION
(Fix #124, #180)

In corescript version 1.6.1, tilemap isn't displayed for a moment after NewGame. (only parallax is displayed)
In other words, drawing maps is delayed at scene starting.
Fixed!
