### PR TITLE
Update Graphics.js

### DIFF
--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -784,6 +784,7 @@ Graphics._updateAllElements = function() {
     this._updateUpperCanvas();
     this._updateRenderer();
     this._paintUpperCanvas();
+    this._updateProgress();
 };
 
 /**


### PR DESCRIPTION
Hello,

** Content of trouble
The loading bar may be displayed outside the screen.

** Reproduction procedure
1. Create a new project with RPG Maker MV version 1.6.1.
2. Apply community-1.3 to the new project you created.
3. Start the test play.
4. Select a new game.
5. Press the F4 key (full screen display).
6. Press the X key (open the menu).
7. Press the X key (close the menu).
8. Press the F4 key (cancel the full screen display).
9. Outside the range of the screen is displayed. The vertical and horizontal scroll bars are displayed.

This phenomenon occurs regardless of whether the loading bar is hidden or displayed.

** Cause
This is because the size of Graphics._progressElement (element id: 'loading-progress') is not changed to its original size.

** How to fix
Assuming that the loading bar is scaled to fit the screen,
Add this._updateProgress() in Graphics._updateAllElements
If there is no intention to scale it will be another solution.
Since we are going through the enlarging process, we corrected it by assuming that it would likely be scaled up.
Please consider.
