### PR TITLE
Cover exception by undefined _progressListener

### DIFF
--- a/js/rpg_core/ProgressWatcher.js
+++ b/js/rpg_core/ProgressWatcher.js
@@ -12,7 +12,7 @@ ProgressWatcher._bitmapListener = function(bitmap){
     this._countLoading++;
     bitmap.addLoadListener(function(){
         this._countLoaded++;
-        this._progressListener(this._countLoaded, this._countLoading);
+        this._progressListener && this._progressListener(this._countLoaded, this._countLoading);
     }.bind(this));
 };
 
@@ -20,7 +20,7 @@ ProgressWatcher._audioListener = function(audio){
     this._countLoading++;
     audio.addLoadListener(function(){
         this._countLoaded++;
-        this._progressListener(this._countLoaded, this._countLoading);
+        this._progressListener && this._progressListener(this._countLoaded, this._countLoading);
     }.bind(this));
 };
 


### PR DESCRIPTION
Raises `Object doesn't support property or method '_progressListener'` exception in rare cases on microsoft edge browser.

Possibly, `_bitmapListener` or `_audioListener` were executed **BEFORE** `setProgressListener`.

I suppose to can omit to execute `_progressListener` when not have `_progressListener`.

Sorry for my poor english.