### PR TITLE
Fix progress bar width for small width games

### DIFF
--- a/js/rpg_core/Graphics.js
+++ b/js/rpg_core/Graphics.js
@@ -269,7 +269,6 @@ Graphics.startLoading = function() {
 Graphics._setupProgress = function(){
     this._progressElement = document.createElement('div');
     this._progressElement.id = 'loading-progress';
-    this._progressElement.width = 600;
     this._progressElement.height = 300;
     this._progressElement.style.visibility = 'hidden';
 
@@ -281,6 +280,7 @@ Graphics._setupProgress = function(){
     this._barElement.style.border = '5px solid white';
     this._barElement.style.borderRadius = '15px';
     this._barElement.style.marginTop = '40%';
+    this._barElement.style.boxSizing = 'border-box';
 
     this._filledBarElement = document.createElement('div');
     this._filledBarElement.id = 'loading-filled-bar';
@@ -321,6 +321,7 @@ Graphics._updateProgressCount = function(countLoaded, countLoading){
 };
 
 Graphics._updateProgress = function(){
+    this._progressElement.width = Math.min(this._width * 0.9, 600);
     this._centerElement(this._progressElement);
 };
 


### PR DESCRIPTION
Fixed an issue where the progress bar was larger than the game screen,
if I set the `screenWidth` value to less than `610` in `CommunityBasic.js`
(It is happen with a game for smartphones :sob: :iphone: )

<img width="265" src="https://user-images.githubusercontent.com/1131422/57980236-84ceb100-7a63-11e9-9b25-033ca8737c06.png">

<img src="https://user-images.githubusercontent.com/1131422/57980217-33262680-7a63-11e9-9ae5-ddc2fadd71e8.jpg" width="200">

Video:
https://youtu.be/urLdUwQpIOM

----------

I tried the following two changes! :laughing:

(1)
I added a process to recalculate the width to `Graphics._updateProgress`.
(like `Graphics._updateErrorPrinter`)

(2)
I added `border-box` style to `Graphics._barElement`.
`Graphics._barElement` has a width of 100% and has a 5px border.
Therefore, the element width was 610 px ( `100% + 5 px * 2` )