### PR TITLE
Make Datamanager compatible with some plugins.

### DIFF
--- a/js/rpg_managers/DataManager.js
+++ b/js/rpg_managers/DataManager.js
@@ -149,7 +149,7 @@ DataManager.onLoad = function(object) {
 
 DataManager.extractMetadata = function(data) {
     var re = /<([^<>:]+)(:?)([^>]*)>/g;
-    data.meta = {};
+    data.meta = data.meta || {};
     for (;;) {
         var match = re.exec(data.note);
         if (match) {


### PR DESCRIPTION
Some Plugins like CCEX Dynamic Actors: http://sumrndm.site/ccex-dynamic-actors/ 
Write some additional data in the meta attribute of an equipment.
The DataManager always resets the meta attribute, this leads to the loss of information.