### PR TITLE
fix sound not playing under certain operations (smartphone)

### DIFF
--- a/js/rpg_core/WebAudio.js
+++ b/js/rpg_core/WebAudio.js
@@ -211,7 +211,7 @@ WebAudio._onHide = function() {
  */
 WebAudio._onShow = function() {
     if (this._shouldMuteOnHide()) {
-        this._fadeIn(0.5);
+        this._fadeIn(1);
     }
 };
 


### PR DESCRIPTION
I found a `WebAudio._onVisibilityChange` problem.

`WebAudio._onHide` and `WebAudio._onShow` adjust the volume when the browser visibility changes for Smartphone (especially Android OS).
But, `WebAudio._onHide` and `WebAudio._onShow have different fade duration.

- WebAudio._onHide : 1sec
- WebAudio._onShow : 0.5sec

The following operations will cause problems.

1. Launch game on Android Chrome
2. Press the home button to hide Chrome (and run `WebAudio._onHide` )
3. Open Chrome within 0.5 seconds (= 1sec - 0.5sec)

When this operation is performed, the fade-out time will be longer than the fade-in time.
Then the sound will be muted all the time :cry:
