### PR TITLE
Window_NameEdit : Trim the extra whitespace

### DIFF
--- a/js/rpg_windows/Window_NameEdit.js
+++ b/js/rpg_windows/Window_NameEdit.js
@@ -35,7 +35,7 @@ Window_NameEdit.prototype.windowHeight = function() {
 };
 
 Window_NameEdit.prototype.name = function() {
-    return this._name;
+    return this._name.trim();
 };
 
 Window_NameEdit.prototype.restoreDefault = function() {


### PR DESCRIPTION
This allows for RPG Developers to test if character names match up with a certain value correctly. 

E.g Currently: Users can name their character "Connor  " and the name will not be registered as "Connor".