### PR TITLE
Update Decrypter.decryptImg for encoding

### DIFF
--- a/js/rpg_core/Decrypter.js
+++ b/js/rpg_core/Decrypter.js
@@ -27,7 +27,7 @@ Decrypter.decryptImg = function(url, bitmap) {
     url = this.extToEncryptExt(url);
 
     var requestFile = new XMLHttpRequest();
-    requestFile.open("GET", url);
+    requestFile.open("GET", decodeURIComponent(url));
     requestFile.responseType = "arraybuffer";
     requestFile.send();
 


### PR DESCRIPTION
If an image file has characters that get encoded and is attempted to be unencrypted; the image will refuse to load and crash the game.